### PR TITLE
fix_spin_box_live_updated

### DIFF
--- a/src/negui_parameters.cpp
+++ b/src/negui_parameters.cpp
@@ -84,7 +84,7 @@ void MyDoubleParameter::updateInputWidget() {
 }
 
 void MyDoubleParameter::connectInputWidget() {
-    connect(_inputWidget, SIGNAL(editingFinished()), this, SIGNAL(isUpdated()));
+    connect(_inputWidget, SIGNAL(valueChanged(double)), this, SIGNAL(isUpdated()));
 }
 
 void MyDoubleParameter::reset() {
@@ -191,7 +191,7 @@ void MyIntegerParameter::updateInputWidget() {
 }
 
 void MyIntegerParameter::connectInputWidget() {
-    connect(_inputWidget, SIGNAL(editingFinished()), this, SIGNAL(isUpdated()));
+    connect(_inputWidget, SIGNAL(valueChanged(int)), this, SIGNAL(isUpdated()));
 }
 
 void MyIntegerParameter::reset() {


### PR DESCRIPTION
The bug with stroke(border)-width changes is fixed and and their changes are now porjected on the being modifying element in a real-time manner. This fixes #17