### PR TITLE
Fixing the bug with the position of newly added shapes through right side menu

### DIFF
--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -172,6 +172,8 @@ void MyClassicNodeSceneGraphicsItem::moveBy(qreal dx, qreal dy) {
 }
 
 void MyClassicNodeSceneGraphicsItem::adjustOriginalPosition() {
+    // TODO leads to an error in the position for newly added shapes.
+    /*
     QPointF extentsCenter = getExtents().center();
     for (QGraphicsItem* item : childItems()) {
         MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
@@ -179,6 +181,7 @@ void MyClassicNodeSceneGraphicsItem::adjustOriginalPosition() {
             casted_item->adjustOriginalPosition(extentsCenter - (_originalPosition + pos()));
     }
     _originalPosition = extentsCenter - pos();
+     */
 }
 
 void MyClassicNodeSceneGraphicsItem::updateExtents(const QRectF& extents) {


### PR DESCRIPTION
The function adjutsOriginalPosition adjusts the originalposition attribute of the elemnt graphics item so that the newly added graphics shapes are added in the center of group of graphics shapes. If this function is enabled, the newly added graphics shapes should know how the other items are adjusted before so that they can be adjusted accordingly. For now, this function is disabled.