### PR TITLE
An element is kept selected while the feature menu is showing its features

### DIFF
--- a/src/negui_arrow_head_graphics_item.cpp
+++ b/src/negui_arrow_head_graphics_item.cpp
@@ -71,6 +71,11 @@ void MyArrowHeadSceneGraphicsItem::enableSelectEdgeMode() {
     setCursor(Qt::ArrowCursor);
 }
 
+void MyArrowHeadSceneGraphicsItem::enableDisplayFeatureMenuMode() {
+    MyNetworkElementGraphicsItemBase::enableDisplayFeatureMenuMode();
+    setCursor(Qt::ArrowCursor);
+}
+
 // MyArrowHeadIconGraphicsItem
 
 MyArrowHeadIconGraphicsItem::MyArrowHeadIconGraphicsItem(const QPointF& position, const qreal& rotation, QGraphicsItem *parent) : MyArrowHeadGraphicsItemBase(parent) {

--- a/src/negui_arrow_head_graphics_item.h
+++ b/src/negui_arrow_head_graphics_item.h
@@ -33,6 +33,8 @@ public:
     void enableAddEdgeMode() override;
 
     void enableSelectEdgeMode() override;
+    
+    void enableDisplayFeatureMenuMode() override;
 };
 
 class MyArrowHeadIconGraphicsItem : public MyArrowHeadGraphicsItemBase {

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -167,6 +167,12 @@ void MyEdgeBase::enableSelectEdgeMode() {
         arrowHead()->enableSelectEdgeMode();
 }
 
+void MyEdgeBase::enableDisplayFeatureMenuMode() {
+    MyNetworkElementBase::enableDisplayFeatureMenuMode();
+    if (isSetArrowHead())
+        arrowHead()->enableDisplayFeatureMenuMode();
+}
+
 const QPointF MyEdgeBase::middlePosition() {
     return 0.5 * (((MyNodeBase*)sourceNode())->getExtents().center() + ((MyNodeBase*)targetNode())->getExtents().center());
 }

--- a/src/negui_edge.h
+++ b/src/negui_edge.h
@@ -64,6 +64,8 @@ public:
     void enableAddEdgeMode() override;
     
     void enableSelectEdgeMode() override;
+    
+    void enableDisplayFeatureMenuMode() override;
 
     const QPointF middlePosition();
     

--- a/src/negui_edge_graphics_item.cpp
+++ b/src/negui_edge_graphics_item.cpp
@@ -87,6 +87,11 @@ void MyEdgeSceneGraphicsItemBase::enableSelectEdgeMode() {
     setCursor(Qt::PointingHandCursor);
 }
 
+void MyEdgeSceneGraphicsItemBase::enableDisplayFeatureMenuMode() {
+    MyNetworkElementGraphicsItemBase::enableDisplayFeatureMenuMode();
+    setCursor(Qt::ArrowCursor);
+}
+
 // MyClassicEdgeSceneGraphicsItem
 
 MyClassicEdgeSceneGraphicsItem::MyClassicEdgeSceneGraphicsItem(QGraphicsItem *parent) : MyEdgeSceneGraphicsItemBase(parent) {

--- a/src/negui_edge_graphics_item.h
+++ b/src/negui_edge_graphics_item.h
@@ -54,6 +54,8 @@ public:
     void enableAddEdgeMode() override;
 
     void enableSelectEdgeMode() override;
+    
+    void enableDisplayFeatureMenuMode() override;
 };
 
 class MyClassicEdgeSceneGraphicsItem: public MyEdgeSceneGraphicsItemBase {

--- a/src/negui_graphics_scene.cpp
+++ b/src/negui_graphics_scene.cpp
@@ -93,8 +93,9 @@ void MyGraphicsScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 }
 
 void MyGraphicsScene::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
-    emit mouseLeftButtonIsDoubleClicked();
     QGraphicsScene::mouseDoubleClickEvent(event);
+    if (!event->isAccepted())
+        emit mouseLeftButtonIsDoubleClicked();
 }
 
 void MyGraphicsScene::keyPressEvent(QKeyEvent *event) {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -849,6 +849,7 @@ void MyInteractor::enableNormalMode() {
 void MyInteractor::enableAddNodeMode(MyPluginItemBase* style) {
     enableNormalMode();
     MySceneModeElementBase::enableAddNodeMode();
+    askForRemoveFeatureMenu();
     setNodeStyle(dynamic_cast<MyNetworkElementStyleBase*>(style));
     for (MyNetworkElementBase *node : qAsConst(nodes()))
         node->enableAddNodeMode();
@@ -861,6 +862,7 @@ void MyInteractor::enableAddNodeMode(MyPluginItemBase* style) {
 void MyInteractor::enableAddEdgeMode(MyPluginItemBase* style) {
     enableNormalMode();
     MySceneModeElementBase::enableAddEdgeMode();
+    askForRemoveFeatureMenu();
     setEdgeStyle(dynamic_cast<MyNetworkElementStyleBase*>(style));
     for (MyNetworkElementBase *node : qAsConst(nodes()))
         node->enableAddEdgeMode();

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -318,6 +318,7 @@ void MyInteractor::addNode(MyNetworkElementBase* n) {
         connect(n, SIGNAL(askForDeleteNetworkElement(MyNetworkElementBase*)), this, SLOT(deleteNode(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
         connect(n, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
+        connect(n, SIGNAL(askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)), this, SIGNAL(askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)));
         connect(n, SIGNAL(askForCopyNetworkElement(MyNetworkElementBase*)), this, SLOT(setCopiedNode(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForCutNetworkElement(MyNetworkElementBase*)), this, SLOT(setCutNode(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForCopyNetworkElementStyle(MyNetworkElementStyleBase*)), this, SLOT(setCopiedNodeStyle(MyNetworkElementStyleBase*)));

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -1112,6 +1112,7 @@ QList<QToolButton*> MyInteractor::getAddModeButtons() {
 QToolButton* MyInteractor::createNormalModeMenuButton() {
     QToolButton* button = new MyModeToolButton("Normal");
     connect(button, SIGNAL(clicked()), this, SLOT(enableNormalMode()));
+    connect(button, SIGNAL(clicked()), this, SIGNAL(askForRemoveFeatureMenu()));
     return button;
 }
 

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -736,6 +736,23 @@ void MyInteractor::selectElement(MyNetworkElementBase* element) {
     }
 }
 
+void MyInteractor::selectElement(const QString& elementName) {
+    for (MyNetworkElementBase* node : qAsConst(nodes())) {
+        if (node->name() == elementName) {
+            if (!node->isSelected())
+                node->setSelected(true);
+            return;
+        }
+    }
+    for (MyNetworkElementBase* edge  : qAsConst(edges())) {
+        if (edge->name() == elementName) {
+            if (!edge->isSelected())
+                edge->setSelected(true);
+            return;
+        }
+    }
+}
+
 const bool MyInteractor::areAnyOtherElementsSelected(MyNetworkElementBase* element) {
     for (MyNetworkElementBase* node : qAsConst(nodes())) {
         if (node->isSelected() && node != element)
@@ -872,6 +889,12 @@ void MyInteractor::enableSelectEdgeMode(const QString& edgeCategory) {
         edge->enableSelectEdgeMode();
     
     emit askForSetToolTip("Select " + edgeCategory + " edges");
+}
+
+void MyInteractor::enableDisplayFeatureMenuMode(const QString& elementName) {
+    enableNormalMode();
+    MySceneModeElementBase::enableDisplayFeatureMenuMode();
+    selectElement(elementName);
 }
 
 void MyInteractor::displaySelectionArea(const QPointF& position) {

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -138,6 +138,7 @@ public slots:
     const QList<MyNetworkElementBase*> selectedNodes();
     const QList<MyNetworkElementBase*> selectedEdges();
     void selectElement(MyNetworkElementBase* element);
+    void unselectElement(MyNetworkElementBase* element);
     void selectElement(const QString& elementName);
     void selectElements(const bool& selected);
     void selectElements(const bool& selected, const QString& category);

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -138,6 +138,7 @@ public slots:
     const QList<MyNetworkElementBase*> selectedNodes();
     const QList<MyNetworkElementBase*> selectedEdges();
     void selectElement(MyNetworkElementBase* element);
+    void selectElement(const QString& elementName);
     void selectElements(const bool& selected);
     void selectElements(const bool& selected, const QString& category);
     void selectNodes(const bool& selected);
@@ -161,6 +162,7 @@ public slots:
     void enableSelectMode(const QString& elementCategory = "");
     void enableSelectNodeMode(const QString& nodeCategory = "");
     void enableSelectEdgeMode(const QString& edgeCategory = "");
+    void enableDisplayFeatureMenuMode(const QString& elementName);
 
     void displaySelectionArea(const QPointF& position);
     void clearSelectionArea();

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -105,6 +105,7 @@ signals:
     void askForResetScale();
     void askForSetToolTip(const QString& toolTip);
     void askForDisplayFeatureMenu(QWidget*);
+    const bool askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&);
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
     void modeIsSet(const QString&);
     void currentFileNameIsUpdated(const QString&);

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -105,6 +105,7 @@ signals:
     void askForResetScale();
     void askForSetToolTip(const QString& toolTip);
     void askForDisplayFeatureMenu(QWidget*);
+    void askForRemoveFeatureMenu();
     const bool askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&);
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
     void modeIsSet(const QString&);

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -84,6 +84,7 @@ void MyNetworkEditorWidget::setInteractions() {
     /// feature menu
     // display feature menu
     connect((MyInteractor*)interactor(), SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SLOT(displayFeatureMenu(QWidget*)));
+    connect((MyInteractor*)interactor(), SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
     connect((MyInteractor*)interactor(), SIGNAL(askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)), this, SLOT(whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)));
 
     /// mode menu
@@ -191,7 +192,8 @@ void MyNetworkEditorWidget::removeFeatureMenu() {
         _featureMenu->deleteLater();
         _featureMenu = NULL;
     }
-    ((MyInteractor*)interactor())->enableNormalMode();
+    if (((MyInteractor*)interactor())->getSceneMode() == MySceneModeElementBase::DISPLAY_FEATURE_MENU_MODE)
+        ((MyInteractor*)interactor())->enableNormalMode();
 }
 
 const bool MyNetworkEditorWidget::whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString& elementName) {

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -84,6 +84,7 @@ void MyNetworkEditorWidget::setInteractions() {
     /// feature menu
     // display feature menu
     connect((MyInteractor*)interactor(), SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SLOT(displayFeatureMenu(QWidget*)));
+    connect((MyInteractor*)interactor(), SIGNAL(askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)), this, SLOT(whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)));
 
     /// mode menu
     // set mode
@@ -189,6 +190,13 @@ void MyNetworkEditorWidget::removeFeatureMenu() {
         _featureMenu->deleteLater();
         _featureMenu = NULL;
     }
+}
+
+const bool MyNetworkEditorWidget::whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString& elementName) {
+    if (_featureMenu && _featureMenu->objectName() == elementName)
+        return true;
+
+    return false;
 }
 
 void MyNetworkEditorWidget::setReadyToLaunch() {

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -182,6 +182,7 @@ void MyNetworkEditorWidget::displayFeatureMenu(QWidget* featureMenu) {
     removeFeatureMenu();
     ((QGridLayout*)layout())->addWidget(featureMenu, 2, 2, 1, 1, Qt::AlignTop);
     _featureMenu = featureMenu;
+    ((MyInteractor*)interactor())->enableDisplayFeatureMenuMode(_featureMenu->objectName());
 }
 
 void MyNetworkEditorWidget::removeFeatureMenu() {
@@ -190,6 +191,7 @@ void MyNetworkEditorWidget::removeFeatureMenu() {
         _featureMenu->deleteLater();
         _featureMenu = NULL;
     }
+    ((MyInteractor*)interactor())->enableNormalMode();
 }
 
 const bool MyNetworkEditorWidget::whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString& elementName) {

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -49,6 +49,7 @@ private slots:
 
     void displayFeatureMenu(QWidget* featureMenu);
     void removeFeatureMenu();
+    const bool whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString& elementName);
 
 protected:
     

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -126,7 +126,7 @@ QWidget* MyNetworkElementBase::getFeatureMenu() {
 }
 
 void MyNetworkElementBase::createFeatureMenu() {
-    if (getSceneMode() == NORMAL_MODE && !askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(name())) {
+    if ((getSceneMode() == NORMAL_MODE || getSceneMode() == DISPLAY_FEATURE_MENU_MODE) && !askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(name())) {
         MyFeatureMenu* featureMenu =  new MyFeatureMenu(getFeatureMenu(), askForIconsDirectoryPath());
         featureMenu->setObjectName(name());
         featureMenu->setShapeStyles(style()->shapeStyles());

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -25,8 +25,8 @@ void MyNetworkElementBase::updateGraphicsItem() {
 }
 
 void MyNetworkElementBase::connectGraphicsItem() {
-    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForUnselectNetworkElement, this, [this] () { setSelected(false); });
-    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit elementObject(this); });
+    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit askForSelectNetworkElement(this); });
+    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForUnselectNetworkElement, this, [this] () { emit askForUnselectNetworkElement(this); });
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForDeleteNetworkElement, this, [this] () { emit askForDeleteNetworkElement(this); });
     connect(_graphicsItem, SIGNAL(askForWhetherNetworkElementIsSelected()), this, SLOT(isSelected()));
     connect(_graphicsItem, SIGNAL(askForCreateFeatureMenu()), this, SLOT(createFeatureMenu()));
@@ -100,6 +100,11 @@ void MyNetworkElementBase::enableAddEdgeMode() {
 void MyNetworkElementBase::enableSelectEdgeMode() {
     MySceneModeElementBase::enableSelectEdgeMode();
     graphicsItem()->enableSelectEdgeMode();
+}
+
+void MyNetworkElementBase::enableDisplayFeatureMenuMode() {
+    MySceneModeElementBase::enableDisplayFeatureMenuMode();
+    graphicsItem()->enableDisplayFeatureMenuMode();
 }
 
 QWidget* MyNetworkElementBase::getFeatureMenu() {

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -2,6 +2,7 @@
 #include "negui_feature_menu.h"
 
 #include <QGridLayout>
+#include <QTimer>
 
 // MyNetworkElementBase
 
@@ -128,6 +129,13 @@ void MyNetworkElementBase::createFeatureMenu() {
             updateStyle(shapeStyles);
             updateGraphicsItem();
             emit askForCreateChangeStageCommand(); } );
-        emit askForDisplayFeatureMenu(featureMenu);
+        askForDisplayFeatureMenuWithDelay(featureMenu, 200);
     }
+}
+
+void MyNetworkElementBase::askForDisplayFeatureMenuWithDelay(QWidget* featureMenu, const qint32 delayTime) {
+    QTimer* timer = new QTimer();
+    timer->setSingleShot(true);
+    connect(timer, &QTimer::timeout, this, [this, featureMenu] () { askForDisplayFeatureMenu(featureMenu); } );
+    timer->start(delayTime);
 }

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -120,8 +120,9 @@ QWidget* MyNetworkElementBase::getFeatureMenu() {
 }
 
 void MyNetworkElementBase::createFeatureMenu() {
-    if (getSceneMode() == NORMAL_MODE) {
+    if (getSceneMode() == NORMAL_MODE && !askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(name())) {
         MyFeatureMenu* featureMenu =  new MyFeatureMenu(getFeatureMenu(), askForIconsDirectoryPath());
+        featureMenu->setObjectName(name());
         featureMenu->setShapeStyles(style()->shapeStyles());
         connect(featureMenu, &MyFeatureMenu::isUpdated, this, [this] (QList<MyShapeStyleBase*> shapeStyles) {
             updateStyle(shapeStyles);

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -57,6 +57,8 @@ public:
     
     void enableSelectEdgeMode() override;
     
+    void enableDisplayFeatureMenuMode() override;
+    
     virtual const QRectF getExtents() = 0;
     
     virtual QWidget* getFeatureMenu();
@@ -67,7 +69,9 @@ public:
 
 signals:
     
-    void elementObject(MyNetworkElementBase*);
+    void askForSelectNetworkElement(MyNetworkElementBase*);
+
+    void askForUnselectNetworkElement(MyNetworkElementBase*);
     
     void askForCreateChangeStageCommand();
 

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -71,6 +71,8 @@ signals:
 
     void askForDisplayFeatureMenu(QWidget*);
 
+    const bool askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&);
+
     void askForCopyNetworkElement(MyNetworkElementBase*);
 
     void askForCutNetworkElement(MyNetworkElementBase*);

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -62,7 +62,9 @@ public:
     virtual QWidget* getFeatureMenu();
     
     virtual const qint32 calculateZValue() = 0;
-    
+
+    void askForDisplayFeatureMenuWithDelay(QWidget* featureMenu, const qint32 delayTime);
+
 signals:
     
     void elementObject(MyNetworkElementBase*);

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -179,13 +179,11 @@ void MyNetworkElementGraphicsItemBase::mouseReleaseEvent(QGraphicsSceneMouseEven
 }
 
 void MyNetworkElementGraphicsItemBase::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
-    QGraphicsItem::mouseDoubleClickEvent(event);
     if (event->button() == Qt::LeftButton) {
-        event->accept();
         emit mouseLeftButtonIsDoubleClicked();
-        return;
+        event->accept();
     }
-    event->ignore();
+    QGraphicsItem::mouseDoubleClickEvent(event);
 }
 
 void MyNetworkElementGraphicsItemBase::displayContextMenu(const QPoint& position) {

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -111,6 +111,12 @@ void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
     setFlag(QGraphicsItem::ItemIsMovable, false);
 }
 
+void MyNodeSceneGraphicsItemBase::enableDisplayFeatureMenuMode() {
+    MyNetworkElementGraphicsItemBase::enableDisplayFeatureMenuMode();
+    setCursor(Qt::PointingHandCursor);
+    setFlag(QGraphicsItem::ItemIsMovable, false);
+}
+
 QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, const QVariant &value) {
     if (change == ItemPositionChange) {
         deparent();

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -47,6 +47,8 @@ public:
     void enableAddEdgeMode() override;
 
     void enableSelectEdgeMode() override;
+
+    void enableDisplayFeatureMenuMode() override;
     
 signals:
     

--- a/src/negui_scene_mode_element_base.cpp
+++ b/src/negui_scene_mode_element_base.cpp
@@ -23,6 +23,8 @@ void MySceneModeElementBase::setSceneMode(const QString& mode) {
         setSceneMode(SELECT_NODE_MODE);
     else if (mode == "Select_Edge")
         setSceneMode(SELECT_EDGE_MODE);
+    else if (mode == "Display_Feature_Menu_Mode")
+        setSceneMode(DISPLAY_FEATURE_MENU_MODE);
 }
 
 MySceneModeElementBase::SceneMode MySceneModeElementBase::getSceneMode() {
@@ -42,6 +44,8 @@ const QString MySceneModeElementBase::getSceneModeAsString() {
         return "Select_Node";
     else if (_sceneMode == SELECT_EDGE_MODE)
         return "Select_Edge";
+    else if (_sceneMode == DISPLAY_FEATURE_MENU_MODE)
+        return "Display_Feature_Menu_Mode";
 
     return "";
 }
@@ -68,4 +72,8 @@ void MySceneModeElementBase::enableSelectNodeMode() {
 
 void MySceneModeElementBase::enableSelectEdgeMode() {
     setSceneMode(SELECT_EDGE_MODE);
+}
+
+void MySceneModeElementBase::enableDisplayFeatureMenuMode() {
+    setSceneMode(DISPLAY_FEATURE_MENU_MODE);
 }

--- a/src/negui_scene_mode_element_base.h
+++ b/src/negui_scene_mode_element_base.h
@@ -14,6 +14,7 @@ public:
         SELECT_MODE,
         SELECT_NODE_MODE,
         SELECT_EDGE_MODE,
+        DISPLAY_FEATURE_MENU_MODE,
     } SceneMode;
 
     MySceneModeElementBase();
@@ -37,6 +38,8 @@ public:
     virtual void enableSelectNodeMode();
 
     virtual void enableSelectEdgeMode();
+
+    virtual void enableDisplayFeatureMenuMode();
 
 protected:
     SceneMode _sceneMode;


### PR DESCRIPTION
While the feature menu is shown for an element, this element is kept selected and it is not possbile to unselect it unless either another elmenet is selected and the menu is shown for that one, or the menu is closed. To do so, a new scene mode called "Dispaly Feature Menu Mode" is added.
 Also, the dispaly of the feature menu is delayed to resolve the conflifct between single click and double click on a graphics item. This fixes #22 and fixes #18 issues.