### PR TITLE
Bug fixes for setting the plain text of a node

### DIFF
--- a/src/negui_feature_menu.cpp
+++ b/src/negui_feature_menu.cpp
@@ -34,7 +34,7 @@ MyFeatureMenu::MyFeatureMenu(QWidget* elementFeatureMenu, const QString& iconsDi
 
 QList<MyShapeStyleBase*> MyFeatureMenu::shapeStyles() {
     for (MyShapeStyleBase* shapeStyle : qAsConst(_shapeStyles)) {
-        for (MyParameterBase* parameter : qAsConst(shapeStyle->parameters()))
+        for (MyParameterBase* parameter : shapeStyle->parameters() + shapeStyle->outsourcingParameters())
             parameter->setDefaultValue();
     }
 

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -10,7 +10,6 @@ MyNetworkElementBase::MyNetworkElementBase(const QString& name) : MyBase(name) {
     _style = NULL;
     _isActive = false;
     _isSelected = false;
-    _displayName = name;
 }
 
 MyNetworkElementBase::~MyNetworkElementBase() {
@@ -19,14 +18,6 @@ MyNetworkElementBase::~MyNetworkElementBase() {
 
 void MyNetworkElementBase::setName(const QString& name) {
     _name = name;
-}
-
-const QString& MyNetworkElementBase::displayName() {
-    return _displayName;
-}
-
-void MyNetworkElementBase::setDisplayName(const QString& displayName) {
-    _displayName = displayName;
 }
 
 MyNetworkElementGraphicsItemBase* MyNetworkElementBase::graphicsItem() {
@@ -168,17 +159,6 @@ void MyNetworkElementBase::createFeatureMenu() {
             emit askForCreateChangeStageCommand(); } );
         askForDisplayFeatureMenuWithDelay(featureMenu, 200);
     }
-}
-
-void MyNetworkElementBase::addDisplayNameToFeatureMenu(QWidget* featureMenu) {
-    QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
-    QLineEdit* displayNameLineEdit = new MyLineEdit(displayName());
-    connect(displayNameLineEdit, &QLineEdit::textChanged, this, [this, featureMenu] (const QString& text) {
-        setDisplayName(text);
-        ((MyFeatureMenuItemFrame*)featureMenu)->isUpdated();
-    } );
-    contentLayout->addWidget(new MyLabel("Display Name"), contentLayout->rowCount(), 0, Qt::AlignLeft);
-    contentLayout->addWidget(displayNameLineEdit, contentLayout->rowCount() - 1, 0, 1, 2, Qt::AlignRight);
 }
 
 void MyNetworkElementBase::askForDisplayFeatureMenuWithDelay(QWidget* featureMenu, const qint32 delayTime) {

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -24,10 +24,6 @@ public:
     virtual ELEMENT_TYPE type() = 0;
 
     void setName(const QString& name);
-
-    const QString& displayName();
-
-    void setDisplayName(const QString& displayName);
     
     MyNetworkElementGraphicsItemBase* graphicsItem();
     
@@ -70,8 +66,6 @@ public:
     virtual const QRectF getExtents() = 0;
     
     virtual QWidget* getFeatureMenu();
-
-    void addDisplayNameToFeatureMenu(QWidget* featureMenu);
     
     virtual const qint32 calculateZValue() = 0;
 
@@ -125,7 +119,6 @@ protected:
     MyNetworkElementStyleBase* _style;
     bool _isActive;
     bool _isSelected;
-    QString _displayName;
 };
 
 #endif

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -53,7 +53,7 @@ MyShapeGraphicsItemBase* MyNetworkElementGraphicsItemBase::createShapeGraphicsIt
         item->setZValue(zValue());
     }
     else if (style->type() == MyShapeStyleBase::TEXT_SHAPE_STYLE && canAddTextShape()) {
-        item = createTextShape(_originalPosition.x(), _originalPosition.y(), askForElementDisplayName(), this);
+        item = createTextShape(_originalPosition.x(), _originalPosition.y(), askForDisplayName(), this);
         item->setZValue(zValue() + 1);
     }
     else if (style->type() == MyShapeStyleBase::CENTROID_SHAPE_STYLE && canAddCentroidShape()) {

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -84,7 +84,7 @@ signals:
     void askForDeleteNetworkElement();
     const bool askForWhetherElementStyleIsCopied();
     const bool askForWhetherAnyOtherElementsAreSelected();
-    QString askForElementDisplayName();
+    QString askForDisplayName();
 
 public slots:
 

--- a/src/negui_network_element_style_base.cpp
+++ b/src/negui_network_element_style_base.cpp
@@ -40,6 +40,15 @@ void MyNetworkElementStyleBase::clearShapeStyles() {
         delete _shapeStyles.takeLast();
 }
 
+MyParameterBase* MyNetworkElementStyleBase::getParameter(MyShapeStyleBase::SHAPE_STYLE shape, const QString& parameterName) {
+    for (MyShapeStyleBase* shapeStyle : shapeStyles()) {
+        if (shapeStyle->type() == shape)
+            return shapeStyle->findParameter(parameterName);
+    }
+
+    return NULL;
+}
+
 const QRectF MyNetworkElementStyleBase::getShapesExtents(QRectF defaultExtents) {
     qreal extentsX = defaultExtents.x();
     qreal extentsY = defaultExtents.y();

--- a/src/negui_network_element_style_base.h
+++ b/src/negui_network_element_style_base.h
@@ -22,6 +22,8 @@ public:
     virtual MyShapeStyleBase* createShapeStyle(const QString& shape) = 0;
     
     virtual void clearShapeStyles();
+
+    MyParameterBase* getParameter(MyShapeStyleBase::SHAPE_STYLE shape, const QString& parameterName);
     
     virtual const QRectF getShapesExtents(QRectF defaultExtents = QRectF(0.0, 0.0, 0.0, 0.0));
     

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -25,7 +25,6 @@ MyNodeBase::ELEMENT_TYPE MyNodeBase::type() {
 
 void MyNodeBase::connectGraphicsItem() {
     MyNetworkElementBase::connectGraphicsItem();
-    connect((MyNodeGraphicsItemBase*)_graphicsItem, &MyNodeGraphicsItemBase::askForElementDisplayName, this, [this] () { return displayName(); });
     connect(_graphicsItem, SIGNAL(askForDeparent()), this,  SLOT(deparent()));
     connect(_graphicsItem, SIGNAL(askForReparent()), this, SLOT(reparent()));
     connect(_graphicsItem, SIGNAL(askForResetPosition()), this, SLOT(resetPosition()));
@@ -323,8 +322,14 @@ void MyClassicNodeBase::adjustExtents() {
 // MySimpleClassicNode
 
 MySimpleClassicNode::MySimpleClassicNode(const QString& name, const qreal& x, const qreal& y) : MyClassicNodeBase(name, x, y) {
+    _displayName = name;
     _graphicsItem = createGraphicsItem(position());
     connectGraphicsItem();
+}
+
+void MySimpleClassicNode::connectGraphicsItem() {
+    MyNodeBase::connectGraphicsItem();
+    connect((MyNetworkElementGraphicsItemBase*)_graphicsItem, &MyNetworkElementGraphicsItemBase::askForDisplayName, this, [this] () { return displayName(); });
 }
 
 MyNodeBase::NODE_TYPE MySimpleClassicNode::nodeType() {
@@ -335,16 +340,35 @@ MyNetworkElementGraphicsItemBase* MySimpleClassicNode::createGraphicsItem(const 
     return createSimpleClassicNodeSceneGraphicsItem(position);
 }
 
+const QString& MySimpleClassicNode::displayName() {
+    return _displayName;
+}
+
+void MySimpleClassicNode::setDisplayName(const QString& displayName) {
+    _displayName = displayName;
+}
+
 QWidget* MySimpleClassicNode::getFeatureMenu() {
     QWidget* featureMenu = MyNetworkElementBase::getFeatureMenu();
     QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
 
-    MyNetworkElementBase::addDisplayNameToFeatureMenu(featureMenu);
+    addDisplayNameToFeatureMenu(featureMenu);
     addParentFeaturesToFeatureMenu(featureMenu);
     addSpacerItemToFeatureMenu(featureMenu);
     addChangeShapeStyleButtonToFeatureMenu(featureMenu);
 
     return featureMenu;
+}
+
+void MySimpleClassicNode::addDisplayNameToFeatureMenu(QWidget* featureMenu) {
+    //QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
+    //QLineEdit* displayNameLineEdit = new MyLineEdit(displayName());
+    //connect(displayNameLineEdit, &QLineEdit::textChanged, this, [this, featureMenu] (const QString& text) {
+        //setDisplayName(text);
+        //((MyFeatureMenuItemFrame*)featureMenu)->isUpdated();
+    //} );
+    //contentLayout->addWidget(new MyLabel("Display Name"), contentLayout->rowCount(), 0, Qt::AlignLeft);
+    //contentLayout->addWidget(displayNameLineEdit, contentLayout->rowCount() - 1, 0, 1, 2, Qt::AlignRight);
 }
 
 void MySimpleClassicNode::addChangeShapeStyleButtonToFeatureMenu(QWidget* featureMenu) {
@@ -375,12 +399,12 @@ QWidget* MyComplexClassicNode::getFeatureMenu() {
 
     addParentFeaturesToFeatureMenu(featureMenu);
     addSpacerItemToFeatureMenu(featureMenu);
-    addAdddRemoveShapeStyleButtonsToFeatureMenu(featureMenu);
+    addAddRemoveShapeStyleButtonsToFeatureMenu(featureMenu);
 
     return featureMenu;
 }
 
-void MyComplexClassicNode::addAdddRemoveShapeStyleButtonsToFeatureMenu(QWidget* featureMenu) {
+void MyComplexClassicNode::addAddRemoveShapeStyleButtonsToFeatureMenu(QWidget* featureMenu) {
     QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
     QWidget* shapeStylesButtons = ((MyComplexClassicNodeStyle*)style())->shapeStylesButtons();
     connect(shapeStylesButtons, SIGNAL(askForAddShapeStyle(MyShapeStyleBase*)), featureMenu, SIGNAL(askForAddShapeStyle(MyShapeStyleBase*)));

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -361,14 +361,12 @@ QWidget* MySimpleClassicNode::getFeatureMenu() {
 }
 
 void MySimpleClassicNode::addDisplayNameToFeatureMenu(QWidget* featureMenu) {
-    //QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
-    //QLineEdit* displayNameLineEdit = new MyLineEdit(displayName());
-    //connect(displayNameLineEdit, &QLineEdit::textChanged, this, [this, featureMenu] (const QString& text) {
-        //setDisplayName(text);
-        //((MyFeatureMenuItemFrame*)featureMenu)->isUpdated();
-    //} );
-    //contentLayout->addWidget(new MyLabel("Display Name"), contentLayout->rowCount(), 0, Qt::AlignLeft);
-    //contentLayout->addWidget(displayNameLineEdit, contentLayout->rowCount() - 1, 0, 1, 2, Qt::AlignRight);
+    QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
+    MyParameterBase* plainTextParameter = style()->getParameter(MyShapeStyleBase::TEXT_SHAPE_STYLE, "plain-text");
+    if (plainTextParameter) {
+        contentLayout->addWidget(new MyLabel("Display Name"), contentLayout->rowCount(), 0, Qt::AlignLeft);
+        contentLayout->addWidget(plainTextParameter->inputWidget(), contentLayout->rowCount() - 1, 0, 1, 2, Qt::AlignRight);
+    }
 }
 
 void MySimpleClassicNode::addChangeShapeStyleButtonToFeatureMenu(QWidget* featureMenu) {

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -163,11 +163,21 @@ public:
 
     MyNetworkElementGraphicsItemBase* createGraphicsItem(const QPointF &position) override;
 
+    void connectGraphicsItem() override;
+
+    const QString& displayName();
+
+    void setDisplayName(const QString& displayName);
+
     QWidget* getFeatureMenu() override;
 
     void addDisplayNameToFeatureMenu(QWidget* featureMenu);
 
     void addChangeShapeStyleButtonToFeatureMenu(QWidget* featureMenu);
+
+protected:
+
+    QString _displayName;
 };
 
 class MyComplexClassicNode : public MyClassicNodeBase {
@@ -183,7 +193,7 @@ public:
 
     QWidget* getFeatureMenu() override;
 
-    void addAdddRemoveShapeStyleButtonsToFeatureMenu(QWidget* featureMenu);
+    void addAddRemoveShapeStyleButtonsToFeatureMenu(QWidget* featureMenu);
 };
 
 class MyCentroidNode : public MyNodeBase {

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -100,8 +100,7 @@ class MySimpleClassicNodeSceneGraphicsItem : public MyClassicNodeSceneGraphicsIt
 
 public:
 
-    MySimpleClassicNodeSceneGraphicsItem(const QPointF &position, QGraphicsItem *parent = nullptr);;
-
+    MySimpleClassicNodeSceneGraphicsItem(const QPointF &position, QGraphicsItem *parent = nullptr);
 };
 
 class MyComplexClassicNodeSceneGraphicsItem : public MyClassicNodeSceneGraphicsItemBase {
@@ -109,7 +108,7 @@ class MyComplexClassicNodeSceneGraphicsItem : public MyClassicNodeSceneGraphicsI
 
 public:
 
-    MyComplexClassicNodeSceneGraphicsItem(const QPointF &position, QGraphicsItem *parent = nullptr);;
+    MyComplexClassicNodeSceneGraphicsItem(const QPointF &position, QGraphicsItem *parent = nullptr);
 
 };
 

--- a/src/negui_node_style_builder.cpp
+++ b/src/negui_node_style_builder.cpp
@@ -33,22 +33,22 @@ const bool isCentroidNodeStyle(const QJsonObject &json) {
 }
 
 const bool isSimpleClassicNodeStyle(const QJsonObject &json) {
-    if (json.contains("shapes") && json["shapes"].isArray()) {
-        QJsonArray shapesArray = json["shapes"].toArray();
-        QJsonObject textShapeObject;
-        QJsonObject geometricShapeObject;
-        if (shapesArray.size() == 2) {
-            for (unsigned int shapeIndex = 0; shapeIndex < shapesArray.size(); shapeIndex++) {
-                QJsonObject shapeObject = shapesArray[shapeIndex].toObject();
-                if (shapeObject.contains("shape") && shapeObject["shape"].isString()) {
-                    if (shapeObject["shape"].toString() == "text") {
-                        if (!shapeObject.contains("plain-text"))
-                            return true;
-                    }
-                }
+    if (json.contains("shapes") && json["shapes"].isArray())
+        return whetherHaveTwoShapesWithOneOfThemATextShape(json["shapes"].toArray());
+
+    return  false;
+}
+
+const bool whetherHaveTwoShapesWithOneOfThemATextShape(const QJsonArray& shapesArray) {
+    if (shapesArray.size() == 2) {
+        for (unsigned int shapeIndex = 0; shapeIndex < shapesArray.size(); shapeIndex++) {
+            QJsonObject shapeObject = shapesArray[shapeIndex].toObject();
+            if (shapeObject.contains("shape") && shapeObject["shape"].isString()) {
+                if (shapeObject["shape"].toString() == "text")
+                    return true;
             }
         }
     }
 
-    return  false;
+    return false;
 }

--- a/src/negui_node_style_builder.h
+++ b/src/negui_node_style_builder.h
@@ -9,4 +9,6 @@ const bool isCentroidNodeStyle(const QJsonObject &json);
 
 const bool isSimpleClassicNodeStyle(const QJsonObject &json);
 
+const bool whetherHaveTwoShapesWithOneOfThemATextShape(const QJsonArray& shapesArray);
+
 #endif

--- a/src/negui_parameters.cpp
+++ b/src/negui_parameters.cpp
@@ -339,7 +339,7 @@ void MyStringParameter::connectInputWidget() {
 }
 
 void MyStringParameter::reset() {
-    _defaultValue = "text";
+    _defaultValue = "";
     _isSetDefaultValue = false;
 }
 
@@ -883,6 +883,22 @@ MyCentroidFillParameter::MyCentroidFillParameter() : MyFillParameter() {
 
 void MyCentroidFillParameter::reset() {
     setDefaultValue("white");
+}
+
+// MyTextPlainTextParameter
+
+MyTextPlainTextParameter::MyTextPlainTextParameter() : MyStringParameter("plain-text") {
+    reset();
+}
+
+void MyTextPlainTextParameter::connectInputWidget() {
+    connect(_inputWidget, SIGNAL(textChanged(const QString&)), this, SIGNAL(isUpdated()));
+}
+
+
+void MyTextPlainTextParameter::reset() {
+    MyStringParameter::reset();
+    _defaultValue = "text";
 }
 
 // MyFontFamilyParameter

--- a/src/negui_parameters.h
+++ b/src/negui_parameters.h
@@ -630,6 +630,18 @@ public:
     void reset() override;
 };
 
+class MyTextPlainTextParameter : public MyStringParameter {
+
+public:
+
+    MyTextPlainTextParameter();
+
+    void connectInputWidget() override;
+
+    // reset the values of the parameter
+    void reset() override;
+};
+
 class MyFontFamilyParameter : public MyStringParameter {
 public:
 

--- a/src/negui_shape_style_base.cpp
+++ b/src/negui_shape_style_base.cpp
@@ -18,6 +18,10 @@ const QList<MyParameterBase*>& MyShapeStyleBase::parameters() const {
     return _parameters;
 }
 
+const QList<MyParameterBase*>& MyShapeStyleBase::outsourcingParameters() const {
+    return _outsourcingParameters;
+}
+
 void MyShapeStyleBase::addParameter(MyParameterBase* parameter) {
     _parameters.push_back(parameter);
     connect(parameter, SIGNAL(isUpdated()), this, SIGNAL(isUpdated()));
@@ -28,8 +32,13 @@ void MyShapeStyleBase::addParameterToTheBeginningOfTheList(MyParameterBase* para
     connect(parameter, SIGNAL(isUpdated()), this, SIGNAL(isUpdated()));
 }
 
+void MyShapeStyleBase::addOutsourcingParameter(MyParameterBase* parameter) {
+    _outsourcingParameters.push_back(parameter);
+    connect(parameter, SIGNAL(isUpdated()), this, SIGNAL(isUpdated()));
+}
+
 MyParameterBase* MyShapeStyleBase::findParameter(const QString& name) const {
-    for (MyParameterBase* parameter : qAsConst(parameters())) {
+    for (MyParameterBase* parameter : parameters() + outsourcingParameters()) {
         if (parameter->name() == name) {
             return parameter;
         }

--- a/src/negui_shape_style_base.h
+++ b/src/negui_shape_style_base.h
@@ -27,9 +27,13 @@ public:
     // get parameters
     const QList<MyParameterBase*>& parameters() const;
 
+    const QList<MyParameterBase*>& outsourcingParameters() const;
+
     void addParameter(MyParameterBase* parameter);
     
     void addParameterToTheBeginningOfTheList(MyParameterBase* parameter);
+
+    void addOutsourcingParameter(MyParameterBase* parameter);
     
     // find a parameter among the list of parameters using its name
     MyParameterBase* findParameter(const QString& name) const;
@@ -57,6 +61,8 @@ signals:
 
 protected:
     QList<MyParameterBase*> _parameters;
+
+    QList<MyParameterBase*> _outsourcingParameters;
 };
 
 #endif

--- a/src/negui_text_graphics_item.cpp
+++ b/src/negui_text_graphics_item.cpp
@@ -11,13 +11,10 @@ MyTextGraphicsItem::MyTextGraphicsItem(qreal x, qreal y, const QString& elementN
 void MyTextGraphicsItem::updateStyle() {
     if (isSetStyle()) {
         // plain-text
-        if (!_elementName.isEmpty() && ((MyTextStyleBase*)style())->whetherSetNameAsDefaultPlainText()) {
+        if (((MyWithPlainTextTextStyle*)style())->plainText() == "text" && ((MyTextStyleBase*)style())->whetherSetNameAsDefaultPlainText())
             ((MyTextStyleBase*)style())->setPlainText(_elementName);
-            setPlainText(_elementName);
-        }
-        else if (!((MyWithPlainTextTextStyle*)style())->plainText().isEmpty())
-            setPlainText(((MyWithPlainTextTextStyle*)style())->plainText());
-        
+        setPlainText(((MyWithPlainTextTextStyle*)style())->plainText());
+
         // width
         if (((MyTextStyleBase*)style())->width() > 0.001)
             setTextWidth(((MyTextStyleBase*)style())->width());

--- a/src/negui_text_style.cpp
+++ b/src/negui_text_style.cpp
@@ -358,7 +358,7 @@ void MyTextStyleBase::write(QJsonObject &json) {
 // MySimpleTextStyle
 
 MySimpleTextStyle::MySimpleTextStyle(const QString& name) : MyTextStyleBase(name) {
-    addOutsourcingParameter(new MyStringParameter("plain-text"));
+    addOutsourcingParameter(new MyTextPlainTextParameter());
     reset();
     _whetherSetNameAsDefaultPlainText = true;
 }
@@ -378,6 +378,6 @@ void MySimpleTextStyle::write(QJsonObject &json) {
 // MyWithPlainTextTextStyle
 
 MyWithPlainTextTextStyle::MyWithPlainTextTextStyle(const QString& name) : MyTextStyleBase(name) {
-    addParameterToTheBeginningOfTheList(new MyStringParameter("plain-text"));
+    addParameterToTheBeginningOfTheList(new MyTextPlainTextParameter());
     reset();
 }

--- a/src/negui_text_style.cpp
+++ b/src/negui_text_style.cpp
@@ -45,6 +45,20 @@ MyShapeStyleBase::SHAPE_STYLE MyTextStyleBase::type() {
     return TEXT_SHAPE_STYLE;
 }
 
+const QString MyTextStyleBase::plainText() const {
+    MyParameterBase* parameter = findParameter("plain-text");
+    if (parameter)
+        return ((MyStringParameter*)parameter)->defaultValue();
+
+    return "";
+}
+
+void MyTextStyleBase::setPlainText(const QString& plainText) {
+    MyParameterBase* parameter = findParameter("plain-text");
+    if (parameter)
+        ((MyStringParameter *) parameter)->setDefaultValue(plainText);
+}
+
 const QColor MyTextStyleBase::defaultTextColor() const {
     QColor color;
     
@@ -191,6 +205,13 @@ const bool& MyTextStyleBase::whetherSetNameAsDefaultPlainText() const {
 void MyTextStyleBase::read(const QJsonObject &json) {
     My2DShapeStyleBase::read(json);
     MyParameterBase* parameter = NULL;
+
+    // plain-text
+    if (json.contains("plain-text") && json["plain-text"].isString()) {
+        parameter = findParameter("plain-text");
+        if (parameter)
+            ((MyStringParameter *) parameter)->setDefaultValue(json["plain-text"].toString());
+    }
     
     // color
     if (json.contains("color") && json["color"].isString()) {
@@ -274,6 +295,10 @@ void MyTextStyleBase::write(QJsonObject &json) {
     My2DShapeStyleBase::write(json);
     MyParameterBase* parameter = NULL;
 
+    parameter = findParameter("plain-text");
+    if (parameter)
+        json["plain-text"] = ((MyStringParameter*)parameter)->defaultValue();
+
     // color
     parameter = findParameter("color");
     if (parameter)
@@ -333,70 +358,26 @@ void MyTextStyleBase::write(QJsonObject &json) {
 // MySimpleTextStyle
 
 MySimpleTextStyle::MySimpleTextStyle(const QString& name) : MyTextStyleBase(name) {
+    addOutsourcingParameter(new MyStringParameter("plain-text"));
     reset();
     _whetherSetNameAsDefaultPlainText = true;
 }
 
-const QString MySimpleTextStyle::plainText() const {
-    return _plainText;
+void MySimpleTextStyle::read(const QJsonObject &json) {
+    MyTextStyleBase::read(json);
+    _whetherSetNameAsDefaultPlainText = true;
+    if (json.contains("set_name_as_default_plain_text") && json["set_name_as_default_plain_text"].isBool())
+        _whetherSetNameAsDefaultPlainText = json["set_name_as_default_plain_text"].toBool();
 }
 
-void MySimpleTextStyle::setPlainText(const QString& plainText) {
-    _plainText = plainText;
+void MySimpleTextStyle::write(QJsonObject &json) {
+    MyTextStyleBase::write(json);
+    json["set_name_as_default_plain_text"] = whetherSetNameAsDefaultPlainText();
 }
 
 // MyWithPlainTextTextStyle
 
 MyWithPlainTextTextStyle::MyWithPlainTextTextStyle(const QString& name) : MyTextStyleBase(name) {
-    // plain-text
     addParameterToTheBeginningOfTheList(new MyStringParameter("plain-text"));
     reset();
-}
-
-const QString MyWithPlainTextTextStyle::plainText() const {
-    MyParameterBase* parameter = findParameter("plain-text");
-    if (parameter)
-        return ((MyStringParameter*)parameter)->defaultValue();
-
-    return "";
-}
-
-void MyWithPlainTextTextStyle::setPlainText(const QString& plainText) {
-    MyParameterBase* parameter = findParameter("plain-text");
-    if (parameter) {
-        ((MyStringParameter *) parameter)->setDefaultValue(plainText);
-        _whetherSetNameAsDefaultPlainText = false;
-    }
-}
-
-void MyWithPlainTextTextStyle::read(const QJsonObject &json) {
-    MyTextStyleBase::read(json);
-    MyParameterBase* parameter = NULL;
-
-    // plain-text
-    _whetherSetNameAsDefaultPlainText = false;
-    if (json.contains("plain-text") && json["plain-text"].isString()) {
-        parameter = findParameter("plain-text");
-        if (parameter)
-            ((MyStringParameter*)parameter)->setDefaultValue(json["plain-text"].toString());
-    }
-    else {
-        _whetherSetNameAsDefaultPlainText = true;
-        if (json.contains("set_name_as_default_plain_text") && json["set_name_as_default_plain_text"].isBool())
-            _whetherSetNameAsDefaultPlainText = json["set_name_as_default_plain_text"].toBool();
-    }
-}
-
-void MyWithPlainTextTextStyle::write(QJsonObject &json) {
-    MyTextStyleBase::write(json);
-    MyParameterBase* parameter = NULL;
-
-    // plain-text
-    if (whetherSetNameAsDefaultPlainText())
-        json["set_name_as_default_plain_text"] = whetherSetNameAsDefaultPlainText();
-    else {
-        parameter = findParameter("plain-text");
-        if (parameter)
-            json["plain-text"] = ((MyStringParameter*)parameter)->defaultValue();
-    }
 }

--- a/src/negui_text_style.h
+++ b/src/negui_text_style.h
@@ -11,10 +11,10 @@ public:
     SHAPE_STYLE type() override;
 
     // get the plain text for text
-    virtual const QString plainText() const = 0;
+    const QString plainText() const;
 
     // set the plain text for text
-    virtual void setPlainText(const QString& plainText) = 0;
+    void setPlainText(const QString& plainText);
     
     const QRectF getShapeExtents() override;
     
@@ -56,9 +56,8 @@ public:
     
     const qreal verticalPadding() const;
 
-    // set the associated name as the default text
     const bool& whetherSetNameAsDefaultPlainText() const;
-    
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
     
@@ -75,33 +74,17 @@ public:
 
     MySimpleTextStyle(const QString& name);
 
-    // get the plain text for text
-    const QString plainText() const override;
+    // read the node style info from the json object
+    void read(const QJsonObject &json) override;
 
-    // set the plain text for text
-    void setPlainText(const QString& plainText) override;
-
-protected:
-
-    QString _plainText;
+    // write the node style info to the json object
+    void write(QJsonObject &json) override;
 };
 
 class MyWithPlainTextTextStyle : public MyTextStyleBase {
 public:
 
     MyWithPlainTextTextStyle(const QString& name);
-
-    // get the plain text for text
-    const QString plainText() const override;
-
-    // set the plain text for text
-    void setPlainText(const QString& plainText) override;
-
-    // read the node style info from the json object
-    void read(const QJsonObject &json) override;
-
-    // write the node style info to the json object
-    void write(QJsonObject &json) override;
 };
 
 #endif


### PR DESCRIPTION
It is now possible to add outsourcing parameters to the shape styles. Outsourcing parameters are the ones whiich are used by the shape style but are not shown in a menu other than the shape style menu. Plain text is now added as an outsourcing parameter and its input widget is used as the display name line edit in the node feature menus. This fixes the bug with showing the right texdt for a simple classic node, and also resolves #14 issue.