### PR TITLE
When a node is moved, its focused graphics items are updated, accordingly.

### DIFF
--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -316,7 +316,6 @@ void MyInteractor::addNode(MyNetworkElementBase* n) {
         n->updateGraphicsItem();
         connect(n, SIGNAL(askForParentNodeAtPosition(MyNetworkElementBase*, const QPointF&)), this, SLOT(parentNodeAtPosition(MyNetworkElementBase*, const QPointF&)));
         connect(n, SIGNAL(askForSelectNetworkElement(MyNetworkElementBase*)), this, SLOT(selectElement(MyNetworkElementBase*)));
-        connect(n, SIGNAL(askForUnselectNetworkElement(MyNetworkElementBase*)), this, SLOT(unselectElement(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForSelectNetworkElement(MyNetworkElementBase*)), this, SLOT(addNewEdge(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForDeleteNetworkElement(MyNetworkElementBase*)), this, SLOT(deleteNode(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
@@ -456,7 +455,6 @@ void MyInteractor::addEdge(MyNetworkElementBase* e) {
         _edges.push_back(e);
         e->updateGraphicsItem();
         connect(e, SIGNAL(askForSelectNetworkElement(MyNetworkElementBase*)), this, SLOT(selectElement(MyNetworkElementBase*)));
-        connect(e, SIGNAL(askForUnselectNetworkElement(MyNetworkElementBase*)), this, SLOT(unselectElement(MyNetworkElementBase*)));
         connect(e, SIGNAL(askForDeleteNetworkElement(MyNetworkElementBase*)), this, SLOT(deleteEdge(MyNetworkElementBase*)));
         connect(e, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
         connect(e, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
@@ -826,7 +824,6 @@ void MyInteractor::alignSelectedNetworkElements(const QString& alignType) {
         elementAligner->deleteLater();
         createChangeStageCommand();
     }
-    selectElements(false); //TODO maybe all of the aligned ones needs to be selected
 }
 
 const QList<MyNetworkElementBase*> MyInteractor::selectedNodes() {

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -34,7 +34,6 @@ void MyNetworkElementBase::updateFocusedGraphicsItems() {
 
 void MyNetworkElementBase::connectGraphicsItem() {
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit askForSelectNetworkElement(this); });
-    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForUnselectNetworkElement, this, [this] () { emit askForUnselectNetworkElement(this); });
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForDeleteNetworkElement, this, [this] () { emit askForDeleteNetworkElement(this); });
     connect(_graphicsItem, SIGNAL(askForWhetherNetworkElementIsSelected()), this, SLOT(isSelected()));
     connect(_graphicsItem, SIGNAL(askForCreateFeatureMenu()), this, SLOT(createFeatureMenu()));

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -74,8 +74,6 @@ public:
     signals:
     
     void askForSelectNetworkElement(MyNetworkElementBase*);
-
-    void askForUnselectNetworkElement(MyNetworkElementBase*);
     
     void askForCreateChangeStageCommand();
 

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -69,7 +69,6 @@ signals:
     
     void mouseLeftButtonIsPressed();
     void mouseLeftButtonIsDoubleClicked();
-    void askForUnselectNetworkElement();
     void askForSelectNetworkElement();
     const bool askForWhetherNetworkElementIsSelected();
     void askForAddGraphicsItem(QGraphicsItem*);

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -92,8 +92,8 @@ QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, cons
     if (change == ItemPositionChange) {
         deparent();
         moveChildItems(value.toPointF());
-        emit askForUnselectNetworkElement();
         emit askForResetPosition();
+        updateFocusedGraphicsItems();
     }
 
     return QGraphicsItem::itemChange(change, value);


### PR DESCRIPTION
When a node is moved by the user, its focused graphics items are updated so that they are always at the right position. This helps to remove the need for unselecting a node when it is moved. Thus, when a group of nodes are aligned on the scnee, ther is no need to unselect them. This resolves #58 issue.