### PR TITLE
Right-click menu is given a new design and is debugged

### DIFF
--- a/src/negui_context_menu.cpp
+++ b/src/negui_context_menu.cpp
@@ -25,7 +25,9 @@ MyGraphicsSceneContextMenu::MyGraphicsSceneContextMenu(QWidget *parent) : MyCont
     connect(addAction("Copy"), SIGNAL(triggered()), this, SIGNAL(askForCopySelectedNetworkElements()));
     connect(addAction("Cut"), SIGNAL(triggered()), this, SIGNAL(askForCutSelectedNetworkElements()));
     connect(addAction("Paste"), SIGNAL(triggered()), this, SIGNAL(askForPasteCopiedNetworkElements()));
+    addSeparator();
     connect(addAction("Delete"), SIGNAL(triggered()), this, SIGNAL(askForDeleteSelectedNetworkElements()));
+    addSeparator();
     QMenu* alignMenu = addMenu("Align");
     connect(alignMenu->addAction("Align Top"), &QAction::triggered, [this] () { emit askForAlignSelectedNetworkElements("Align Top"); });
     connect(alignMenu->addAction("Align Middle"), &QAction::triggered, [this] () { emit askForAlignSelectedNetworkElements("Align Middle"); });
@@ -57,6 +59,7 @@ void MyGraphicsSceneContextMenu::initializeActionsStatus() {
 
 MyGraphicsItemContextMenuBase::MyGraphicsItemContextMenuBase(QWidget *parent) : MyContextMenuBase(parent) {
     connect(addAction("Features"), SIGNAL(triggered()), this, SIGNAL(askForCreateFeatureMenu()));
+    addSeparator();
 }
 
 void MyGraphicsItemContextMenuBase::initializeActionsStatus() {
@@ -72,6 +75,7 @@ MyNodeGraphicsItemContextMenuBase::MyNodeGraphicsItemContextMenuBase(QWidget *pa
     connect(addAction("Cut"), SIGNAL(triggered()), this, SIGNAL(askForCutNetworkElement()));
     connect(addAction("Copy Style"), SIGNAL(triggered()), this, SIGNAL(askForCopyNetworkElementStyle()));
     connect(addAction("Paste"), SIGNAL(triggered()), this, SIGNAL(askForPasteNetworkElementStyle()));
+    addSeparator();
     connect(addAction("Delete"), SIGNAL(triggered()), this, SIGNAL(askForDeleteNetworkElement()));
 }
 
@@ -96,6 +100,7 @@ void MyCentroidNodeGraphicsItemContextMenu::initializeActionsStatus() {
 MyEdgeGraphicsItemContextMenu::MyEdgeGraphicsItemContextMenu(QWidget *parent) : MyGraphicsItemContextMenuBase(parent) {
     connect(addAction("Copy Style"), SIGNAL(triggered()), this, SIGNAL(askForCopyNetworkElementStyle()));
     connect(addAction("Paste"), SIGNAL(triggered()), this, SIGNAL(askForPasteNetworkElementStyle()));
+    addSeparator();
     connect(addAction("Delete"), SIGNAL(triggered()), this, SIGNAL(askForDeleteNetworkElement()));
 }
 

--- a/src/negui_graphics_scene.cpp
+++ b/src/negui_graphics_scene.cpp
@@ -60,6 +60,10 @@ void MyGraphicsScene::displayContextMenu(const QPointF& position) {
     }
 }
 
+const bool MyGraphicsScene::whetherMouseReleaseEventIsAccepted() {
+    return _whetherMouseReleaseEventIsAccepted;
+}
+
 void MyGraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     QGraphicsScene::mousePressEvent(event);
     if (!event->isAccepted()) {
@@ -85,14 +89,19 @@ void MyGraphicsScene::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
 
 void MyGraphicsScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
     QGraphicsScene::mouseReleaseEvent(event);
-    if (event->button() == Qt::LeftButton) {
-        _isLeftButtonPressed = false;
-        emit mouseLeftButtonIsReleased();
+    _whetherMouseReleaseEventIsAccepted = false;
+    if (!event->isAccepted()) {
+        if (event->button() == Qt::LeftButton) {
+            _isLeftButtonPressed = false;
+            emit mouseLeftButtonIsReleased();
+        }
+        else if (event->button() == Qt::RightButton) {
+            if (getSceneMode() != NORMAL_MODE)
+                emit askForEnableNormalMode();
+        }
     }
-    else if (event->button() == Qt::RightButton) {
-        if (getSceneMode() != NORMAL_MODE)
-            emit askForEnableNormalMode();
-    }
+    else
+        _whetherMouseReleaseEventIsAccepted = true;
 }
 
 void MyGraphicsScene::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {

--- a/src/negui_graphics_scene.h
+++ b/src/negui_graphics_scene.h
@@ -50,6 +50,7 @@ public slots:
     QList<QGraphicsItem *> itemsAtPosition(const QPointF& position);
     const bool isShiftModifierPressed();
     void displayContextMenu(const QPointF& position);
+    const bool whetherMouseReleaseEventIsAccepted();
     
 protected:
     
@@ -62,6 +63,7 @@ protected:
 
     bool _isLeftButtonPressed;
     bool _isShiftModifierPressed;
+    bool _whetherMouseReleaseEventIsAccepted;
     QPointF _cursorPosition;
 };
 

--- a/src/negui_graphics_view.cpp
+++ b/src/negui_graphics_view.cpp
@@ -172,9 +172,11 @@ void MyGraphicsView::mouseMoveEvent(QMouseEvent *event) {
 
 void MyGraphicsView::mouseReleaseEvent(QMouseEvent *event) {
     QGraphicsView::mouseReleaseEvent(event);
-    if (event->button() == Qt::RightButton) {
-        if (!_isPanned)
-            emit askForDisplayContextMenu(event->globalPos());
+    if (!((MyGraphicsScene*)scene())->whetherMouseReleaseEventIsAccepted()) {
+        if (event->button() == Qt::RightButton) {
+            if (!_isPanned)
+                emit askForDisplayContextMenu(event->globalPos());
+        }
     }
     _isPanned = false;
     _panMode = false;

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -220,23 +220,25 @@ void MyNetworkElementGraphicsItemBase::enableNormalMode() {
 }
 
 void MyNetworkElementGraphicsItemBase::mousePressEvent(QGraphicsSceneMouseEvent *event) {
-    QGraphicsItem::mousePressEvent(event);
     if (event->button() == Qt::LeftButton) {
         _isChosen = true;
         emit mouseLeftButtonIsPressed();
         event->accept();
     }
+    QGraphicsItem::mousePressEvent(event);
 }
 
 void MyNetworkElementGraphicsItemBase::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
-    QGraphicsItem::mouseReleaseEvent(event);
     if (event->button() == Qt::LeftButton) {
         _isChosen = false;
         event->accept();
         emit askForCreateChangeStageCommand();
     }
-    else if (event->button() == Qt::RightButton)
+    else if (event->button() == Qt::RightButton) {
         displayContextMenu(event->screenPos());
+        event->accept();
+    }
+    QGraphicsItem::mousePressEvent(event);
 }
 
 void MyNetworkElementGraphicsItemBase::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {


### PR DESCRIPTION
Separators are added to the right-click menu

- a separator is added after 'Features' action
- a separator is added before 'Align' action
- a separator is added before the 'Delete' action

Mouse release event is managed

- mouse release event for a network element graphics item is refactored so that first it receives the event and accepts it if the conditions are met and then pass it to the graphics scene
    
- mouse release event for graphics scene is refactored so that if event is accepted a flag is set to true. This flag will be used by graphics view later
    
- using the created flag in graphics scene, it checks if the event is already accepted by graphics scene and then runs it

This PR resolves #59
