### PR TITLE
Simple Text graphics items are added

### DIFF
--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -30,6 +30,7 @@ void MyNetworkElementGraphicsItemBase::addShapeItems(QList<MyShapeStyleBase*> sh
 void MyNetworkElementGraphicsItemBase::addShapeItem(MyShapeStyleBase* style) {
     MyShapeGraphicsItemBase* item = createShapeGraphicsItem(style);
     if (item) {
+
         item->setStyle(style);
         item->updateStyle();
         QGraphicsItem* casted_item = dynamic_cast<QGraphicsItem*>(item);
@@ -52,8 +53,12 @@ MyShapeGraphicsItemBase* MyNetworkElementGraphicsItemBase::createShapeGraphicsIt
         item = createPolygonShape(_originalPosition.x(), _originalPosition.y(), this);
         item->setZValue(zValue());
     }
-    else if (style->type() == MyShapeStyleBase::TEXT_SHAPE_STYLE && canAddTextShape()) {
-        item = createTextShape(_originalPosition.x(), _originalPosition.y(), askForDisplayName(), this);
+    else if (style->type() == MyShapeStyleBase::SIMPLE_TEXT_SHAPE_STYLE && canAddTextShape()) {
+        item = createSimpleTextShape(_originalPosition.x(), _originalPosition.y(), askForDisplayName(), this);
+        item->setZValue(zValue() + 1);
+    }
+    else if (style->type() == MyShapeStyleBase::WITH_PLAIN_TEXT_TEXT_SHAPE_STYLE && canAddTextShape()) {
+        item = createWithPlainTextTextShape(_originalPosition.x(), _originalPosition.y(), this);
         item->setZValue(zValue() + 1);
     }
     else if (style->type() == MyShapeStyleBase::CENTROID_SHAPE_STYLE && canAddCentroidShape()) {

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -43,7 +43,7 @@ public:
     
     QList<MyShapeStyleBase*> getShapeStyles();
     
-    QList<QGraphicsItem*> createFocusedGraphicsItems();
+    virtual QList<QGraphicsItem*> createFocusedGraphicsItems();
     
     void addFocusedGraphicsItems();
     

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -379,7 +379,7 @@ QWidget* MySimpleClassicNode::getFeatureMenu() {
 
 void MySimpleClassicNode::addDisplayNameToFeatureMenu(QWidget* featureMenu) {
     QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
-    MyParameterBase* plainTextParameter = style()->getParameter(MyShapeStyleBase::TEXT_SHAPE_STYLE, "plain-text");
+    MyParameterBase* plainTextParameter = style()->getParameter(MyShapeStyleBase::SIMPLE_TEXT_SHAPE_STYLE, "plain-text");
     if (plainTextParameter) {
         contentLayout->addWidget(new MyLabel("Display Name"), contentLayout->rowCount(), 0, Qt::AlignLeft);
         contentLayout->addWidget(plainTextParameter->inputWidget(), contentLayout->rowCount() - 1, 0, 1, 2, Qt::AlignRight);

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -191,6 +191,48 @@ MySimpleClassicNodeSceneGraphicsItem::MySimpleClassicNodeSceneGraphicsItem(const
 
 }
 
+QList<QGraphicsItem*> MySimpleClassicNodeSceneGraphicsItem::createFocusedGraphicsItems() {
+    if (whetherShapesAreOneSimpleTextShapeAndAnotherShape()) {
+        QList<QGraphicsItem*> focusedGraphicsItems;
+        QGraphicsItem* focusedGraphicsItem = NULL;
+        QGraphicsItem* shapeFocusedGraphicsItem = NULL;
+        MyShapeGraphicsItemBase* textGraphicsItem = NULL;
+        for (QGraphicsItem* item : childItems()) {
+            MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
+            if (casted_item) {
+                focusedGraphicsItem = casted_item->getFocusedGraphicsItem();
+                if (focusedGraphicsItem) {
+                    focusedGraphicsItems.push_back(focusedGraphicsItem);
+                    shapeFocusedGraphicsItem = focusedGraphicsItem;
+                }
+                else if (casted_item->style()->type() == MyShapeStyleBase::SIMPLE_TEXT_SHAPE_STYLE)
+                    textGraphicsItem = casted_item;
+            }
+        }
+
+        connect(dynamic_cast<QObject*>(shapeFocusedGraphicsItem), SIGNAL(rectIsUpdated(const QRectF&)), textGraphicsItem, SLOT(updateExtents(const QRectF&)));
+        return focusedGraphicsItems;
+    }
+
+    return MyNetworkElementGraphicsItemBase::createFocusedGraphicsItems();
+}
+
+const bool MySimpleClassicNodeSceneGraphicsItem::whetherShapesAreOneSimpleTextShapeAndAnotherShape() {
+    bool oneSimpleTextShapeExists = false;
+    bool oneOtherShapeExists = false;
+    if (childItems().size() == 2) {
+        for (QGraphicsItem* item : childItems()) {
+            MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
+            if (casted_item->style()->type() == MyShapeStyleBase::SIMPLE_TEXT_SHAPE_STYLE)
+                oneSimpleTextShapeExists = true;
+            else
+                oneOtherShapeExists = true;
+        }
+    }
+
+    return oneSimpleTextShapeExists && oneOtherShapeExists;
+}
+
 // MyComplexClassicNodeSceneGraphicsItem
 
 MyComplexClassicNodeSceneGraphicsItem::MyComplexClassicNodeSceneGraphicsItem(const QPointF &position, QGraphicsItem *parent) : MyClassicNodeSceneGraphicsItemBase(position, parent) {

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -101,6 +101,10 @@ class MySimpleClassicNodeSceneGraphicsItem : public MyClassicNodeSceneGraphicsIt
 public:
 
     MySimpleClassicNodeSceneGraphicsItem(const QPointF &position, QGraphicsItem *parent = nullptr);
+
+    QList<QGraphicsItem*> createFocusedGraphicsItems() override;
+
+    const bool whetherShapesAreOneSimpleTextShapeAndAnotherShape();
 };
 
 class MyComplexClassicNodeSceneGraphicsItem : public MyClassicNodeSceneGraphicsItemBase {

--- a/src/negui_parameters.cpp
+++ b/src/negui_parameters.cpp
@@ -319,7 +319,8 @@ void MyStringParameter::setDefaultValue(const QString& value) {
 }
 
 void MyStringParameter::setDefaultValue() {
-    setDefaultValue(((MyLineEdit*)_inputWidget)->text());
+    if (_inputWidget)
+        setDefaultValue(((MyLineEdit*)_inputWidget)->text());
 }
 
 const QString& MyStringParameter::defaultValue() const {

--- a/src/negui_shape_graphics_item_builder.cpp
+++ b/src/negui_shape_graphics_item_builder.cpp
@@ -30,8 +30,12 @@ MyShapeGraphicsItemBase* createConnectedToEndCentroidShapeLineShape(const QLineF
     return new MyConnectedToEndCentroidShapeLineGraphicsItem(line, parent);
 }
 
-MyShapeGraphicsItemBase* createTextShape(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent) {
-    return new MyTextGraphicsItem(x, y, elementName, parent);
+MyShapeGraphicsItemBase* createSimpleTextShape(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent) {
+    return new MySimpleTextGraphicsItem(x, y, elementName, parent);
+}
+
+MyShapeGraphicsItemBase* createWithPlainTextTextShape(qreal x, qreal y, QGraphicsItem *parent) {
+    return new MyWithPlainTextTextGraphicsItem(x, y, parent);
 }
 
 MyShapeGraphicsItemBase* createCentroidShape(qreal x, qreal y, QGraphicsItem *parent) {

--- a/src/negui_shape_graphics_item_builder.h
+++ b/src/negui_shape_graphics_item_builder.h
@@ -16,7 +16,9 @@ MyShapeGraphicsItemBase* createConnectedToStartCentroidShapeLineShape(const QLin
 
 MyShapeGraphicsItemBase* createConnectedToEndCentroidShapeLineShape(const QLineF& line, QGraphicsItem *parent);
 
-MyShapeGraphicsItemBase* createTextShape(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent);
+MyShapeGraphicsItemBase* createSimpleTextShape(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent);
+
+MyShapeGraphicsItemBase* createWithPlainTextTextShape(qreal x, qreal y, QGraphicsItem *parent);
 
 MyShapeGraphicsItemBase* createCentroidShape(qreal x, qreal y, QGraphicsItem *parent);
 

--- a/src/negui_shape_style_base.cpp
+++ b/src/negui_shape_style_base.cpp
@@ -22,6 +22,10 @@ const QList<MyParameterBase*>& MyShapeStyleBase::outsourcingParameters() const {
     return _outsourcingParameters;
 }
 
+const QList<MyParameterBase*>& MyShapeStyleBase::hiddenParameters() const {
+    return _hiddenParameters;
+}
+
 void MyShapeStyleBase::addParameter(MyParameterBase* parameter) {
     _parameters.push_back(parameter);
     connect(parameter, SIGNAL(isUpdated()), this, SIGNAL(isUpdated()));
@@ -37,8 +41,13 @@ void MyShapeStyleBase::addOutsourcingParameter(MyParameterBase* parameter) {
     connect(parameter, SIGNAL(isUpdated()), this, SIGNAL(isUpdated()));
 }
 
+void MyShapeStyleBase::addHiddenParameter(MyParameterBase* parameter) {
+    _hiddenParameters.push_back(parameter);
+    connect(parameter, SIGNAL(isUpdated()), this, SIGNAL(isUpdated()));
+}
+
 MyParameterBase* MyShapeStyleBase::findParameter(const QString& name) const {
-    for (MyParameterBase* parameter : parameters() + outsourcingParameters()) {
+    for (MyParameterBase* parameter : parameters() + outsourcingParameters() + hiddenParameters()) {
         if (parameter->name() == name) {
             return parameter;
         }

--- a/src/negui_shape_style_base.h
+++ b/src/negui_shape_style_base.h
@@ -14,7 +14,8 @@ public:
         RECTANGLE_SHAPE_STYLE,
         POLYGON_SHAPE_STYLE,
         LINE_SHAPE_STYLE,
-        TEXT_SHAPE_STYLE,
+        SIMPLE_TEXT_SHAPE_STYLE,
+        WITH_PLAIN_TEXT_TEXT_SHAPE_STYLE,
         CENTROID_SHAPE_STYLE,
     } SHAPE_STYLE;
     
@@ -29,11 +30,15 @@ public:
 
     const QList<MyParameterBase*>& outsourcingParameters() const;
 
+    const QList<MyParameterBase*>& hiddenParameters() const;
+
     void addParameter(MyParameterBase* parameter);
     
     void addParameterToTheBeginningOfTheList(MyParameterBase* parameter);
 
     void addOutsourcingParameter(MyParameterBase* parameter);
+
+    void addHiddenParameter(MyParameterBase* parameter);
     
     // find a parameter among the list of parameters using its name
     MyParameterBase* findParameter(const QString& name) const;
@@ -61,8 +66,8 @@ signals:
 
 protected:
     QList<MyParameterBase*> _parameters;
-
     QList<MyParameterBase*> _outsourcingParameters;
+    QList<MyParameterBase*> _hiddenParameters;
 };
 
 #endif

--- a/src/negui_text_graphics_item.cpp
+++ b/src/negui_text_graphics_item.cpp
@@ -2,17 +2,15 @@
 #include "negui_text_style.h"
 #include "negui_resize_handled_graphics_item.h"
 
-// MyTextGraphicsItem
+// MyTextGraphicsItemBase
 
-MyTextGraphicsItem::MyTextGraphicsItem(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent) : My2DShapeGraphicsItemBase(x, y), QGraphicsTextItem(parent) {
-    _elementName = elementName;
+MyTextGraphicsItemBase::MyTextGraphicsItemBase(qreal x, qreal y, QGraphicsItem *parent) : My2DShapeGraphicsItemBase(x, y), QGraphicsTextItem(parent) {
+
 }
 
-void MyTextGraphicsItem::updateStyle() {
+void MyTextGraphicsItemBase::updateStyle() {
     if (isSetStyle()) {
         // plain-text
-        if (((MyWithPlainTextTextStyle*)style())->plainText() == "text" && ((MyTextStyleBase*)style())->whetherSetNameAsDefaultPlainText())
-            ((MyTextStyleBase*)style())->setPlainText(_elementName);
         setPlainText(((MyWithPlainTextTextStyle*)style())->plainText());
 
         // width
@@ -34,15 +32,15 @@ void MyTextGraphicsItem::updateStyle() {
     }
 }
 
-void MyTextGraphicsItem::setSelectedWithBorderColor(const bool& selected) {
+void MyTextGraphicsItemBase::setSelectedWithBorderColor(const bool& selected) {
     QGraphicsItem::setSelected(selected);
 }
 
-void MyTextGraphicsItem::setSelectedWithFillColor(const bool& selected) {
+void MyTextGraphicsItemBase::setSelectedWithFillColor(const bool& selected) {
     QGraphicsItem::setSelected(selected);
 }
 
-void MyTextGraphicsItem::updateExtents(const QRectF& extents) {
+void MyTextGraphicsItemBase::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // x
         ((MyTextStyleBase*)style())->setX(extents.x() - (movedDistance().x() + _originalPosition.x()));
@@ -56,29 +54,54 @@ void MyTextGraphicsItem::updateExtents(const QRectF& extents) {
         // height
         ((MyTextStyleBase*)style())->setHeight(extents.height());
     }
-    
+
     updateStyle();
 }
 
-QRectF MyTextGraphicsItem::getExtents() {
+QRectF MyTextGraphicsItemBase::getExtents() {
     return QRectF(((MyTextStyleBase*)style())->x() + (movedDistance().x() + _originalPosition.x()), ((MyTextStyleBase*)style())->y() + (movedDistance().y() + _originalPosition.y()), ((MyTextStyleBase*)style())->width(), ((MyTextStyleBase*)style())->height());
 }
 
-void MyTextGraphicsItem::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
+void MyTextGraphicsItemBase::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
     ((MyTextStyleBase*)style())->setX(((MyTextStyleBase*)style())->x() - originalPositionMovedDistance.x());
     ((MyTextStyleBase*)style())->setY(((MyTextStyleBase*)style())->y() - originalPositionMovedDistance.y());
     _originalPosition += originalPositionMovedDistance;
 }
 
-QGraphicsItem* MyTextGraphicsItem::getFocusedGraphicsItem() {
+void MyTextGraphicsItemBase::setZValue(qreal z) {
+    QGraphicsItem::setZValue(z);
+}
+
+// MySimpleTextGraphicsItem
+
+MySimpleTextGraphicsItem::MySimpleTextGraphicsItem(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent) : MyTextGraphicsItemBase(x, y, parent)  {
+    _elementName = elementName;
+}
+
+void MySimpleTextGraphicsItem::updateStyle() {
+    if (isSetStyle()) {
+        if (((MyTextStyleBase *) style())->plainText() == "text" &&
+            ((MySimpleTextStyle *) style())->whetherSetNameAsDefaultPlainText())
+            ((MyTextStyleBase *) style())->setPlainText(_elementName);
+    }
+    MyTextGraphicsItemBase::updateStyle();
+}
+
+QGraphicsItem* MySimpleTextGraphicsItem::getFocusedGraphicsItem() {
+    return NULL;
+}
+
+// MyWithPlainTextTextGraphicsItem
+
+MyWithPlainTextTextGraphicsItem::MyWithPlainTextTextGraphicsItem(qreal x, qreal y, QGraphicsItem *parent) : MyTextGraphicsItemBase(x, y, parent)  {
+
+}
+
+QGraphicsItem* MyWithPlainTextTextGraphicsItem::getFocusedGraphicsItem() {
     QRectF focusedRect = getExtents();
     MyResizeHandledGraphicsItemBase* focusedGraphicsItem = new MyResizeHandledGraphicsItem(focusedRect, zValue());
     MyShapeGraphicsItemBase::connect(focusedGraphicsItem, SIGNAL(rectIsUpdated(const QRectF&)), (MyShapeGraphicsItemBase*)this, SLOT(updateExtents(const QRectF&)));
 
     return focusedGraphicsItem;
-}
-
-void MyTextGraphicsItem::setZValue(qreal z) {
-    QGraphicsItem::setZValue(z);
 }
 

--- a/src/negui_text_graphics_item.h
+++ b/src/negui_text_graphics_item.h
@@ -5,10 +5,10 @@
 #include <QTextDocument>
 #include <QPainter>
 
-class MyTextGraphicsItem: public My2DShapeGraphicsItemBase, public QGraphicsTextItem {
+class MyTextGraphicsItemBase: public My2DShapeGraphicsItemBase, public QGraphicsTextItem {
 public:
     
-    MyTextGraphicsItem(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent);
+    MyTextGraphicsItemBase(qreal x, qreal y, QGraphicsItem *parent);
     
     void updateStyle() override;
     
@@ -18,18 +18,35 @@ public:
     
     QRectF getExtents() override;
     
-    QGraphicsItem* getFocusedGraphicsItem() override;
-    
     void setZValue(qreal z) override;
     
     void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) override;
     
 public slots:
+
     void updateExtents(const QRectF& extents) override;
+};
+
+class MySimpleTextGraphicsItem: public MyTextGraphicsItemBase {
+public:
+
+    MySimpleTextGraphicsItem(qreal x, qreal y, const QString& elementName, QGraphicsItem *parent);
+
+    void updateStyle() override;
+
+    QGraphicsItem* getFocusedGraphicsItem() override;
 
 protected:
 
     QString _elementName;
+};
+
+class MyWithPlainTextTextGraphicsItem: public MyTextGraphicsItemBase {
+public:
+
+    MyWithPlainTextTextGraphicsItem(qreal x, qreal y, QGraphicsItem *parent);
+
+    QGraphicsItem* getFocusedGraphicsItem() override;
 };
 
 

--- a/src/negui_text_style.cpp
+++ b/src/negui_text_style.cpp
@@ -19,30 +19,13 @@ MyTextStyleBase::MyTextStyleBase(const QString& name) : My2DShapeStyleBase(name)
     // font-style
     addParameter(new MyFontStyleParameter());
     
-    // x
-    addParameter(new MyNodeTextPositionalParameter("x"));
-    
-    // y
-    addParameter(new MyNodeTextPositionalParameter("y"));
-    
-    // width
-    addParameter(new MyNodeTextDimensionalParameter("width"));
-    
-    // height
-    addParameter(new MyNodeTextDimensionalParameter("height"));
-    
     // horizontal alignment
     addParameter(new MyTextAnchorParameter());
     
     // vertical alignment
     addParameter(new MyVTextAnchorParameter());
 
-    _whetherSetNameAsDefaultPlainText = false;
     reset();
-}
-
-MyShapeStyleBase::SHAPE_STYLE MyTextStyleBase::type() {
-    return TEXT_SHAPE_STYLE;
 }
 
 const QString MyTextStyleBase::plainText() const {
@@ -198,10 +181,6 @@ const qreal MyTextStyleBase::verticalPadding() const {
     return 0.000;
 }
 
-const bool& MyTextStyleBase::whetherSetNameAsDefaultPlainText() const {
-    return _whetherSetNameAsDefaultPlainText;
-}
-
 void MyTextStyleBase::read(const QJsonObject &json) {
     My2DShapeStyleBase::read(json);
     MyParameterBase* parameter = NULL;
@@ -275,7 +254,7 @@ void MyTextStyleBase::read(const QJsonObject &json) {
         if (parameter)
             ((MyDimensionalParameter*)parameter)->setDefaultValue(json["height"].toDouble());
     }
-    
+
     // horizontal alignment
     if (json.contains("text-anchor") && json["text-anchor"].isString()) {
         parameter = findParameter("text-anchor");
@@ -343,7 +322,7 @@ void MyTextStyleBase::write(QJsonObject &json) {
     parameter = findParameter("height");
     if (parameter)
         json["height"] = ((MyDimensionalParameter*)parameter)->defaultValue();
-    
+
     // horizontal alignment
     parameter = findParameter("text-anchor");
     if (parameter)
@@ -358,9 +337,31 @@ void MyTextStyleBase::write(QJsonObject &json) {
 // MySimpleTextStyle
 
 MySimpleTextStyle::MySimpleTextStyle(const QString& name) : MyTextStyleBase(name) {
+    // plain-text
     addOutsourcingParameter(new MyTextPlainTextParameter());
-    reset();
+
+    // x
+    addHiddenParameter(new MyNodeTextPositionalParameter("x"));
+
+    // y
+    addHiddenParameter(new MyNodeTextPositionalParameter("y"));
+
+    // width
+    addHiddenParameter(new MyNodeTextDimensionalParameter("width"));
+
+    // height
+    addHiddenParameter(new MyNodeTextDimensionalParameter("height"));
+
     _whetherSetNameAsDefaultPlainText = true;
+    reset();
+}
+
+MyShapeStyleBase::SHAPE_STYLE MySimpleTextStyle::type() {
+    return SIMPLE_TEXT_SHAPE_STYLE;
+}
+
+const bool& MySimpleTextStyle::whetherSetNameAsDefaultPlainText() const {
+    return _whetherSetNameAsDefaultPlainText;
 }
 
 void MySimpleTextStyle::read(const QJsonObject &json) {
@@ -378,6 +379,24 @@ void MySimpleTextStyle::write(QJsonObject &json) {
 // MyWithPlainTextTextStyle
 
 MyWithPlainTextTextStyle::MyWithPlainTextTextStyle(const QString& name) : MyTextStyleBase(name) {
+    // plain text
     addParameterToTheBeginningOfTheList(new MyTextPlainTextParameter());
+
+    // x
+    addParameter(new MyNodeTextPositionalParameter("x"));
+
+    // y
+    addParameter(new MyNodeTextPositionalParameter("y"));
+
+    // width
+    addParameter(new MyNodeTextDimensionalParameter("width"));
+
+    // height
+    addParameter(new MyNodeTextDimensionalParameter("height"));
+
     reset();
+}
+
+MyShapeStyleBase::SHAPE_STYLE MyWithPlainTextTextStyle::type() {
+    return WITH_PLAIN_TEXT_TEXT_SHAPE_STYLE;
 }

--- a/src/negui_text_style.h
+++ b/src/negui_text_style.h
@@ -7,8 +7,6 @@ class MyTextStyleBase : public My2DShapeStyleBase {
 public:
     
     MyTextStyleBase(const QString& name);
-    
-    SHAPE_STYLE type() override;
 
     // get the plain text for text
     const QString plainText() const;
@@ -56,11 +54,25 @@ public:
     
     const qreal verticalPadding() const;
 
+    // read the node style info from the json object
+    void read(const QJsonObject &json) override;
+    
+    // write the node style info to the json object
+    void write(QJsonObject &json) override;
+};
+
+class MySimpleTextStyle : public MyTextStyleBase {
+public:
+
+    MySimpleTextStyle(const QString& name);
+
+    SHAPE_STYLE type() override;
+
     const bool& whetherSetNameAsDefaultPlainText() const;
 
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
-    
+
     // write the node style info to the json object
     void write(QJsonObject &json) override;
 
@@ -69,22 +81,12 @@ protected:
     bool _whetherSetNameAsDefaultPlainText;
 };
 
-class MySimpleTextStyle : public MyTextStyleBase {
-public:
-
-    MySimpleTextStyle(const QString& name);
-
-    // read the node style info from the json object
-    void read(const QJsonObject &json) override;
-
-    // write the node style info to the json object
-    void write(QJsonObject &json) override;
-};
-
 class MyWithPlainTextTextStyle : public MyTextStyleBase {
 public:
 
     MyWithPlainTextTextStyle(const QString& name);
+
+    SHAPE_STYLE type() override;
 };
 
 #endif


### PR DESCRIPTION
Text graphics item class is split to a base class with simple text graphics item and with plain text text graphics item classes being derived from it.
    
- update style is overridden for simple text graphics item
    
- get focused graphics item is overridden for both derived classes so that there is no focused graphics item created for simple text graphics item

This PR resolves #42, resolves #47, and resolves #49