### PR TITLE
Bug fixes for setting current file name

### DIFF
--- a/src/negui_file_manager.cpp
+++ b/src/negui_file_manager.cpp
@@ -55,6 +55,7 @@ const QString& MyFileManager::workingDirectory() {
 void MyFileManager::resetCurrentExportTool() {
     if (_exportTools.size())
         setCurrentExportTool(_exportTools.at(0));
+    setCurrentExportTool(NULL);
 }
 
 void MyFileManager::setCurrentExportTool(MyPluginItemBase* exportTool) {


### PR DESCRIPTION
When file manager is reset, if there no export tool are loaded into it, current export tool is set to NULL.