### PR TITLE
Graphics View and Graphics Scene Rects are handled:

### DIFF
--- a/src/negui_feature_menu.cpp
+++ b/src/negui_feature_menu.cpp
@@ -8,6 +8,7 @@
 MyFeatureMenu::MyFeatureMenu(QWidget* elementFeatureMenu, const QString& iconsDirectoryPath, QWidget *parent) : MyFrame(parent) {
     _expandableWidgetSize = QSize(0, 0);
     QGridLayout* contentLayout = new QGridLayout(this);
+    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
 
     QPushButton* closeFeatureMenuButton = new QPushButton();
     decorateCloseFeatureMenuButton(closeFeatureMenuButton, iconsDirectoryPath);

--- a/src/negui_feature_menu.cpp
+++ b/src/negui_feature_menu.cpp
@@ -93,17 +93,13 @@ void MyFeatureMenu::setExpandableWidgetSize(const QSize& expandableWidgetSize) {
 
 void MyFeatureMenu::updateExtents() {
     qint32 menuWidth = 0;
-    qint32 menuHeight = 0;
-    
     QSize elementFeatureMenuSize = ((MyFeatureMenuItemFrame*)_elementFeatureMenu)->extents();
     if (elementFeatureMenuSize.width() > menuWidth)
         menuWidth = elementFeatureMenuSize.width();
-    menuHeight += elementFeatureMenuSize.height();
     
     if (_expandableWidgetSize.width() > menuWidth)
         menuWidth = _expandableWidgetSize.width();
-    menuHeight += _expandableWidgetSize.height();
-    setFixedSize(qMax(menuWidth, 300), qMax(menuHeight, 350));
+    setFixedWidth(qMax(menuWidth, 300));
 }
 
 

--- a/src/negui_graphics_scene.cpp
+++ b/src/negui_graphics_scene.cpp
@@ -4,7 +4,7 @@
 // MyGraphicsScene
 
 MyGraphicsScene::MyGraphicsScene(QWidget* parent) : QGraphicsScene(parent) {
-    setSceneRect(30.0, 20.0, 840.0, 560.0);
+    setSceneRect(-10000, -10000, 20000, 20000);
     _isLeftButtonPressed = false;
     _isShiftModifierPressed = false;
 }

--- a/src/negui_graphics_scene.cpp
+++ b/src/negui_graphics_scene.cpp
@@ -21,6 +21,10 @@ void MyGraphicsScene::removeGraphicsItem(QGraphicsItem* item) {
     removeItem(item);
 }
 
+const QRectF MyGraphicsScene::networkExtents() {
+    return itemsBoundingRect();
+}
+
 void MyGraphicsScene::clearScene() {
     clear();
 }

--- a/src/negui_graphics_scene.h
+++ b/src/negui_graphics_scene.h
@@ -46,6 +46,7 @@ public slots:
     void setSceneRect(qreal x, qreal y, qreal width, qreal height);
     void addGraphicsItem(QGraphicsItem* item);
     void removeGraphicsItem(QGraphicsItem* item);
+    const QRectF networkExtents();
     void clearScene();
     QList<QGraphicsItem *> itemsAtPosition(const QPointF& position);
     const bool isShiftModifierPressed();

--- a/src/negui_graphics_view.cpp
+++ b/src/negui_graphics_view.cpp
@@ -22,11 +22,11 @@ MyGraphicsView::MyGraphicsView(QWidget* parent) : QGraphicsView(parent) {
     _isPanned = false;
     
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    setGeometry(75, 50, 900, 600);
     setScene(new MyGraphicsScene(this));
+    setSceneRect(scene()->sceneRect().x(), scene()->sceneRect().y(), scene()->sceneRect().width(), scene()->sceneRect().height());
     connect(this, SIGNAL(askForDisplayContextMenu(const QPointF&)), scene(), SLOT(displayContextMenu(const QPointF&)));
     setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-    setFixedSize(1200, 900);
+    resetScale();
 };
 
 const qreal MyGraphicsView::currentScale() const {
@@ -87,13 +87,13 @@ void MyGraphicsView::exportFigureAsSVG(const QString& fileName, const QRectF& pa
 
 void MyGraphicsView::resetScale() {
     resetTransform();
+    centerOn(sceneRect().center());
 }
 
 void MyGraphicsView::scalingTime(qreal x) {
     qreal factor = 1.0 + qreal(_numScheduledScalings) / 10000.0;
-    if ((factor  > 1.00000 && (currentScale() < _maxScale)) || (factor  < 1.00000 && (currentScale() > _minScale))) {
+    if ((factor  > 1.00000 && (currentScale() < _maxScale)) || (factor  < 1.00000 && (currentScale() > _minScale)))
         scale(factor, factor);
-    }
 }
 
 void MyGraphicsView::animFinished() {

--- a/src/negui_graphics_view.cpp
+++ b/src/negui_graphics_view.cpp
@@ -26,6 +26,7 @@ MyGraphicsView::MyGraphicsView(QWidget* parent) : QGraphicsView(parent) {
     setScene(new MyGraphicsScene(this));
     connect(this, SIGNAL(askForDisplayContextMenu(const QPointF&)), scene(), SLOT(displayContextMenu(const QPointF&)));
     setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
+    setFixedSize(1200, 900);
 };
 
 const qreal MyGraphicsView::currentScale() const {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -261,7 +261,7 @@ void MyInteractor::resetNetwork() {
     clearNodesInfo();
     clearEdgesInfo();
     emit askForClearScene();
-    setNetworkExtents(30.0, 20.0, 840.0, 560.0);
+    setNetworkExtents(0.0, 0.0, 0.0, 0.0);
 }
 
 void MyInteractor::setNetworkExtents(const QJsonObject& json) {
@@ -270,20 +270,7 @@ void MyInteractor::setNetworkExtents(const QJsonObject& json) {
 }
 
 void MyInteractor::setNetworkExtents(qreal x, qreal y, qreal width, qreal height) {
-    qreal minWidth = 840.0;
-    qreal minHeight = 560.0;
-    if (width < minWidth) {
-        x -= 0.5 * (minWidth - width);
-        width = minWidth;
-    }
-    
-    if (height < minHeight) {
-        y -= 0.5 * (minHeight - height);
-        height = minHeight;
-    }
-    
     _networkExtents = QRectF(x, y, width, height);
-    emit askForSetSceneRect(x, y, width, height);
 }
 
 const QRectF& MyInteractor::networkExtents() {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -227,7 +227,6 @@ void MyInteractor::setSceneMode(SceneMode sceneMode) {
 
 void MyInteractor::createNetwork(const QJsonObject& json) {
     resetNetwork();
-    setNetworkExtents(json);
     addNodes(json);
     addEdges(json);
 }
@@ -261,20 +260,6 @@ void MyInteractor::resetNetwork() {
     clearNodesInfo();
     clearEdgesInfo();
     emit askForClearScene();
-    setNetworkExtents(0.0, 0.0, 0.0, 0.0);
-}
-
-void MyInteractor::setNetworkExtents(const QJsonObject& json) {
-    if (json.contains("position") && json["position"].isObject() && json["position"].toObject().contains("x") && json["position"]["x"].isDouble() && json["position"].toObject().contains("y") && json["position"]["y"].isDouble() && json.contains("dimensions") && json["dimensions"].isObject() && json["dimensions"].toObject().contains("width") && json["dimensions"]["width"].isDouble() && json["dimensions"].toObject().contains("height") && json["dimensions"]["height"].isDouble())
-        setNetworkExtents(json["position"]["x"].toDouble() - 0.5 * json["dimensions"]["width"].toDouble(), json["position"]["y"].toDouble() - 0.5 * json["dimensions"]["height"].toDouble(), json["dimensions"]["width"].toDouble(), json["dimensions"]["height"].toDouble());
-}
-
-void MyInteractor::setNetworkExtents(qreal x, qreal y, qreal width, qreal height) {
-    _networkExtents = QRectF(x, y, width, height);
-}
-
-const QRectF& MyInteractor::networkExtents() {
-    return _networkExtents;
 }
 
 QList<MyNetworkElementBase*>& MyInteractor::nodes() {
@@ -647,19 +632,21 @@ bool MyInteractor::edgeExists(MyNetworkElementBase* n1, MyNetworkElementBase* n2
     return false;
 }
 
+#include "iostream"
 QJsonObject MyInteractor::exportNetworkInfo() {
     QJsonObject json;
-    
+
+    QRectF networkExtents = askForNetworkExtents();
     // position
     QJsonObject positionObject;
-    positionObject["x"] = networkExtents().x() + 0.5 * networkExtents().width();
-    positionObject["y"] = networkExtents().y() + 0.5 * networkExtents().height();
+    positionObject["x"] = networkExtents.x() + 0.5 * networkExtents.width();
+    positionObject["y"] = networkExtents.y() + 0.5 * networkExtents.height();
     json["position"] = positionObject;
     
     // dimensions
     QJsonObject dimensionsObject;
-    dimensionsObject["width"] = networkExtents().width();
-    dimensionsObject["height"] = networkExtents().height();
+    dimensionsObject["width"] = networkExtents.width();
+    dimensionsObject["height"] = networkExtents.height();
     json["dimensions"] = dimensionsObject;
     
     // nodes

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -60,9 +60,6 @@ public:
     void resetNetworkCanvas();
     void resetCanvas();
     void resetNetwork();
-    void setNetworkExtents(const QJsonObject& json);
-    void setNetworkExtents(qreal x, qreal y, qreal width, qreal height);
-    const QRectF& networkExtents();
     
     // nodes
     QList<MyNetworkElementBase*>& nodes();
@@ -100,6 +97,7 @@ signals:
     void askForExportFigure(const QString& fileName, const QString& fileExtension);
     void askForAddGraphicsItem(QGraphicsItem* item);
     void askForRemoveGraphicsItem(QGraphicsItem* item);
+    const QRectF askForNetworkExtents();
     void askForClearScene();
     void askForResetScale();
     void askForSetToolTip(const QString& toolTip);
@@ -285,7 +283,6 @@ protected:
     QGraphicsItem* _selectionAreaGraphicsItem;
     
     // network
-    QRectF _networkExtents;
     QJsonObject _stageInfo;
 
     // file

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -100,7 +100,6 @@ signals:
     void askForExportFigure(const QString& fileName, const QString& fileExtension);
     void askForAddGraphicsItem(QGraphicsItem* item);
     void askForRemoveGraphicsItem(QGraphicsItem* item);
-    void askForSetSceneRect(qreal x, qreal y, qreal width, qreal height);
     void askForClearScene();
     void askForResetScale();
     void askForSetToolTip(const QString& toolTip);

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -15,7 +15,6 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     setObjectName("main_widget");
     setStyleSheet("QFrame {background-color : white}");
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    setMinimumSize(QSize(950, 600));
     readSettings();
 
     setWidgets();
@@ -107,9 +106,6 @@ void MyNetworkEditorWidget::setInteractions() {
     /// graphics scene
     // set scene mode
     connect((MyInteractor*)interactor(), &MyInteractor::modeIsSet, ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), [this] (const QString& mode) { ((MyGraphicsScene*)((MyGraphicsView*)view())->scene())->setSceneMode(mode); });
-
-    // set scene rect
-    connect((MyInteractor*)interactor(), SIGNAL(askForSetSceneRect(qreal, qreal, qreal, qreal)), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(setSceneRect(qreal, qreal, qreal, qreal)));
     
     // add graphics item
     connect((MyInteractor*)interactor(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(addGraphicsItem(QGraphicsItem*)));

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -112,7 +112,10 @@ void MyNetworkEditorWidget::setInteractions() {
     
     // remove graphics item
     connect((MyInteractor*)interactor(), SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(removeGraphicsItem(QGraphicsItem*)));
-    
+
+    // network extents
+    connect((MyInteractor*)interactor(), SIGNAL(askForNetworkExtents()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(networkExtents()));
+
     // reset scene
     connect((MyInteractor*)interactor(), SIGNAL(askForClearScene()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(clearScene()));
     

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -14,10 +14,8 @@
 MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) {
     setObjectName("main_widget");
     setStyleSheet("QFrame {background-color : white}");
-    
-    setMinimumSize(120, 80);
-    resize(1050, 700);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    setMinimumSize(QSize(950, 600));
     readSettings();
 
     setWidgets();
@@ -26,10 +24,12 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     QGridLayout* layout = new QGridLayout();
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(toolBar(), layout->rowCount(), 0, 1, 3);
-    layout->addWidget(modeMenu(), layout->rowCount(), 0, 1, 1, Qt::AlignTop | Qt::AlignLeft);
-    layout->addWidget(view(), layout->rowCount() - 1, 1, 1, 1);
+    _layoutMenuRow = layout->rowCount();
+    layout->addWidget(modeMenu(), layout->rowCount(), 0, Qt::AlignTop | Qt::AlignLeft);
+    layout->addWidget(view(), layout->rowCount() - 1, 1);
     layout->addWidget(statusBar(), layout->rowCount(), 0, 1, 3);
     setLayout(layout);
+    arrangeWidgetLayers();
 
     setReadyToLaunch();
 }
@@ -40,9 +40,9 @@ MyNetworkEditorWidget::~MyNetworkEditorWidget() {
 
 void MyNetworkEditorWidget::setWidgets() {
     _toolBar = new MyToolBar(this);
+    _statusBar = new MyStatusBar(this);
     _modeMenu = new MyFrequentlyUsedButtonsModeMenu(this);
     _view = new MyGraphicsView(this);
-    _statusBar = new MyStatusBar(this);
     _interactor = new MyInteractor(this);
     _featureMenu = NULL;
 
@@ -165,6 +165,19 @@ void MyNetworkEditorWidget::setInteractions() {
     connect(((MyGraphicsView*)view())->scene(), SIGNAL(mousePositionIsChanged(const QPointF&)), statusBar(), SLOT(setCoordinatesToMousePosition(const QPointF&)));
 }
 
+void MyNetworkEditorWidget::arrangeWidgetLayers() {
+    modeMenu()->stackUnder(toolBar());
+    modeMenu()->stackUnder(statusBar());
+    if (featureMenu()) {
+        featureMenu()->stackUnder(toolBar());
+        featureMenu()->stackUnder(statusBar());
+        view()->stackUnder(featureMenu());
+    }
+    view()->stackUnder(toolBar());
+    view()->stackUnder(statusBar());
+    view()->stackUnder(modeMenu());
+}
+
 QObject* MyNetworkEditorWidget::interactor() {
     return _interactor;
 }
@@ -185,18 +198,28 @@ QWidget* MyNetworkEditorWidget::statusBar() {
     return _statusBar;
 }
 
+QWidget* MyNetworkEditorWidget::featureMenu() {
+    return _featureMenu;
+}
+
+const qreal& MyNetworkEditorWidget::layoutMenuRow() {
+    return _layoutMenuRow;
+}
+
 void MyNetworkEditorWidget::displayFeatureMenu(QWidget* featureMenu) {
     connect(featureMenu, SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
     removeFeatureMenu();
-    ((QGridLayout*)layout())->addWidget(featureMenu, 2, 2, 1, 1, Qt::AlignTop);
+    ((QGridLayout*)layout())->addWidget(featureMenu, layoutMenuRow(), 2, Qt::AlignTop | Qt::AlignRight);
+    featureMenu->setFixedHeight(height());
     _featureMenu = featureMenu;
     ((MyInteractor*)interactor())->enableDisplayFeatureMenuMode(_featureMenu->objectName());
+    arrangeWidgetLayers();
 }
 
 void MyNetworkEditorWidget::removeFeatureMenu() {
-    if (_featureMenu) {
-        layout()->removeWidget(_featureMenu);
-        _featureMenu->deleteLater();
+    if (featureMenu()) {
+        layout()->removeWidget(featureMenu());
+        featureMenu()->deleteLater();
         _featureMenu = NULL;
     }
     if (((MyInteractor*)interactor())->getSceneMode() == MySceneModeElementBase::DISPLAY_FEATURE_MENU_MODE)
@@ -204,7 +227,7 @@ void MyNetworkEditorWidget::removeFeatureMenu() {
 }
 
 const bool MyNetworkEditorWidget::whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString& elementName) {
-    if (_featureMenu && _featureMenu->objectName() == elementName)
+    if (featureMenu() && featureMenu()->objectName() == elementName)
         return true;
 
     return false;

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -18,6 +18,7 @@ public:
     QWidget* modeMenu();
     QWidget* view();
     QWidget* statusBar();
+    QWidget* featureMenu();
     void readSettings();
     void writeSettings();
 
@@ -55,6 +56,8 @@ protected:
     
     void setWidgets();
     void setInteractions();
+    void arrangeWidgetLayers();
+    const qreal& layoutMenuRow();
     void setReadyToLaunch();
     void closeEvent(QCloseEvent *event) override;
 
@@ -64,6 +67,7 @@ protected:
     QWidget* _modeMenu;
     QWidget* _featureMenu;
     QWidget* _statusBar;
+    qreal _layoutMenuRow;
 };
 
 #endif

--- a/src/negui_mode_menu.cpp
+++ b/src/negui_mode_menu.cpp
@@ -9,7 +9,7 @@ MyModeMenuBase::MyModeMenuBase(QWidget *parent) : MyFrame(parent) {
     QGridLayout* contentLayout = new QGridLayout(this);
     setLayout(contentLayout);
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
-    setMinimumSize(QSize(0, 0));
+    setFixedSize(QSize(0, 0));
 }
 
 void MyModeMenuBase::setNormalModeButton(QAbstractButton* button, const QString& iconsDirectoryPath) {
@@ -18,7 +18,7 @@ void MyModeMenuBase::setNormalModeButton(QAbstractButton* button, const QString&
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
     button->setFixedSize(QSize(buttonSize(), buttonSize()));
-    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
+    setFixedSize(QSize(qMax(width(), button->width() + buttonPadding()), height() + button->height() + buttonPadding()));
 }
 
 void MyModeMenuBase::setFrequentlyUsedButtons(QList<QAbstractButton*> buttons, const QString& iconsDirectoryPath) {
@@ -35,7 +35,7 @@ void MyModeMenuBase::setZoomInButton(QAbstractButton* button, const QString& ico
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
     button->setFixedSize(QSize(buttonSize(), buttonSize()));
-    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
+    setFixedSize(QSize(qMax(width(), button->width() + buttonPadding()), height() + button->height() + buttonPadding()));
 }
 
 void MyModeMenuBase::setZoomOutButton(QAbstractButton* button, const QString& iconsDirectoryPath) {
@@ -44,7 +44,7 @@ void MyModeMenuBase::setZoomOutButton(QAbstractButton* button, const QString& ic
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
     button->setFixedSize(QSize(buttonSize(), buttonSize()));
-    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
+    setFixedSize(QSize(qMax(width(), button->width() + buttonPadding()), height() + button->height() + buttonPadding()));
 }
 
 void MyModeMenuBase::setMode(const QString& mode) {
@@ -98,7 +98,7 @@ void MyFrequentlyUsedButtonsModeMenu::setFrequentlyUsedButtons(QList<QAbstractBu
         contentLayout->addWidget(button, contentLayout->rowCount(), 0);
         _buttons.push_back(button);
         button->setFixedSize(QSize(buttonSize(), buttonSize()));
-        setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
+        setFixedSize(QSize(qMax(width(), button->width() + buttonPadding()), height() + button->height() + buttonPadding()));
     }
 }
 
@@ -113,7 +113,7 @@ void MyAddModeButtonsModeMenu::setAddModeButtons(QList<QAbstractButton*> buttons
     QAbstractButton* button = decorateAddModeButton(buttons, iconsDirectoryPath);
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
-    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
+    setFixedSize(QSize(qMax(width(), button->width() + buttonPadding()), height() + button->height() + buttonPadding()));
 }
 
 const bool isModeToolButton(QAbstractButton* button) {

--- a/src/negui_mode_menu.cpp
+++ b/src/negui_mode_menu.cpp
@@ -8,6 +8,8 @@
 MyModeMenuBase::MyModeMenuBase(QWidget *parent) : MyFrame(parent) {
     QGridLayout* contentLayout = new QGridLayout(this);
     setLayout(contentLayout);
+    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+    setMinimumSize(QSize(0, 0));
 }
 
 void MyModeMenuBase::setNormalModeButton(QAbstractButton* button, const QString& iconsDirectoryPath) {
@@ -15,6 +17,8 @@ void MyModeMenuBase::setNormalModeButton(QAbstractButton* button, const QString&
     decorateNormalModeButton(button, iconsDirectoryPath);
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
+    button->setFixedSize(QSize(buttonSize(), buttonSize()));
+    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
 }
 
 void MyModeMenuBase::setFrequentlyUsedButtons(QList<QAbstractButton*> buttons, const QString& iconsDirectoryPath) {
@@ -30,6 +34,8 @@ void MyModeMenuBase::setZoomInButton(QAbstractButton* button, const QString& ico
     decorateZoomInButton(button, iconsDirectoryPath);
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
+    button->setFixedSize(QSize(buttonSize(), buttonSize()));
+    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
 }
 
 void MyModeMenuBase::setZoomOutButton(QAbstractButton* button, const QString& iconsDirectoryPath) {
@@ -37,7 +43,8 @@ void MyModeMenuBase::setZoomOutButton(QAbstractButton* button, const QString& ic
     decorateZoomOutButton(button, iconsDirectoryPath);
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
-
+    button->setFixedSize(QSize(buttonSize(), buttonSize()));
+    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
 }
 
 void MyModeMenuBase::setMode(const QString& mode) {
@@ -71,6 +78,14 @@ void MyModeMenuBase::deactivateButtons() {
     }
 }
 
+qint32 MyModeMenuBase::buttonSize() {
+    return 45.0;
+}
+
+qint32 MyModeMenuBase::buttonPadding() {
+    return buttonSize() / 3;
+}
+
 // MyFrequentlyUsedButtonsModeMenu
 
 MyFrequentlyUsedButtonsModeMenu::MyFrequentlyUsedButtonsModeMenu(QWidget *parent) : MyModeMenuBase(parent) {
@@ -82,6 +97,8 @@ void MyFrequentlyUsedButtonsModeMenu::setFrequentlyUsedButtons(QList<QAbstractBu
     for (QAbstractButton* button : buttons) {
         contentLayout->addWidget(button, contentLayout->rowCount(), 0);
         _buttons.push_back(button);
+        button->setFixedSize(QSize(buttonSize(), buttonSize()));
+        setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
     }
 }
 
@@ -96,6 +113,7 @@ void MyAddModeButtonsModeMenu::setAddModeButtons(QList<QAbstractButton*> buttons
     QAbstractButton* button = decorateAddModeButton(buttons, iconsDirectoryPath);
     contentLayout->addWidget(button, contentLayout->rowCount(), 0);
     _buttons.push_back(button);
+    setMinimumSize(QSize(qMax(minimumWidth(), button->width() + buttonPadding()), minimumHeight() + button->height() + buttonPadding()));
 }
 
 const bool isModeToolButton(QAbstractButton* button) {

--- a/src/negui_mode_menu.h
+++ b/src/negui_mode_menu.h
@@ -22,6 +22,10 @@ public:
 
     QList<QAbstractButton*> getButtons();
 
+    qint32 buttonSize();
+
+    qint32 buttonPadding();
+
 public slots:
 
     void setMode(const QString& mode);

--- a/src/negui_status_bar.cpp
+++ b/src/negui_status_bar.cpp
@@ -5,6 +5,8 @@
 MyStatusBar::MyStatusBar(QWidget* parent) : QStatusBar(parent) {
     setStyleSheet("QStatusBar {background-color : white; border: 1px solid lightgray;  border-radius: 5px;}");
     setContentsMargins(0, 0, 0, 0);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    setFixedHeight(25);
     _fileNameLabel = new QLabel();
     _coordinatesLabel = new QLabel();
     addPermanentWidget(_fileNameLabel, 97);

--- a/src/negui_toolbar.cpp
+++ b/src/negui_toolbar.cpp
@@ -5,7 +5,9 @@
 MyToolBar::MyToolBar(QWidget* parent) : QToolBar(parent) {
     setStyleSheet("QToolBar {background-color : white; border: 1px solid lightgray;  border-radius: 5px;}");
     setContentsMargins(0, 0, 0, 0);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
     setIconSize(QSize(45, 45));
+    setFixedHeight(45);
 };
 
 void MyToolBar::setButtons(QList<QAbstractButton*> buttons) {

--- a/test-app/src/negui_main_window.cpp
+++ b/test-app/src/negui_main_window.cpp
@@ -43,3 +43,8 @@ void MyMainWindow::connectToCentralWidget(QWidget* menuBar) {
     connect((MyMenuBar*)menuBar, &MyMenuBar::askForName, this, [this] () { return QString(std::string(getName()).c_str()); });
     connect((MyMenuBar*)menuBar, &MyMenuBar::askForVersionNumber, this, [this] () { return QString(std::string(getVersionNumber()).c_str()); });
 }
+
+void MyMainWindow::closeEvent(QCloseEvent *event) {
+    centralWidget()->close();
+    QWidget::closeEvent(event);
+}

--- a/test-app/src/negui_main_window.h
+++ b/test-app/src/negui_main_window.h
@@ -13,6 +13,10 @@ public:
     void setMenuBar();
 
     void connectToCentralWidget(QWidget* menuBar);
+
+private:
+
+    void closeEvent(QCloseEvent *event) override;
 };
 
 #endif


### PR DESCRIPTION
- ask for reset scene rect is removed from interactor
- graphics scene rect extetns is set to the maximum value needed (-5000, -5000, 10000, 10000)
- the extetns of the graphcis scene rect is used for setting scene rect of the graphics view. Also, we make sure that each time the scene is reset, the graphics view shows the centre of the graphics scene.
- network extetns is now updated real-time and it is set to the boudning rect containing all the items on the graphics scene
close event for main window is reimplemented to make sure window extents are memorized for the next app launch

This PR along with PR #68 fixes #36, fixes #37, fixes #38, fixes #45, fixes #50, fixes #51 and fixes #55 issues.