### PR TITLE
bug_fixes_for_element_aligning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,8 @@ set(source_files
 		negui_arrow_head_builder.cpp
 		negui_copied_network_elements_paster.cpp
 		negui_new_edge_builder.cpp
-		negui_element_aligner.cpp
-		negui_element_aligner_builder.cpp
+		negui_network_element_aligner.cpp
+		negui_network_element_aligner_builder.cpp
 		negui_selection_area_graphics_item.cpp
 		negui_network_element_style_base.cpp
 		negui_template_style.cpp
@@ -103,8 +103,8 @@ set(header_files
 		negui_arrow_head_builder.h
         negui_copied_network_elements_paster.h
 		negui_new_edge_builder.h
-		negui_element_aligner.h
-		negui_element_aligner_builder.h
+		negui_network_element_aligner.h
+		negui_network_element_aligner_builder.h
 		negui_selection_area_graphics_item.h
 		negui_network_element_style_base.h
 		negui_template_style.h

--- a/src/negui_element_aligner_builder.h
+++ b/src/negui_element_aligner_builder.h
@@ -1,8 +1,0 @@
-#ifndef __NEGUI_ELEMENT_ALIGNER_BUILDER_H
-#define __NEGUI_ELEMENT_ALIGNER_BUILDER_H
-
-#include "negui_element_aligner.h"
-
-MyElementAlignerBase* createElementAligner(QList<MyNetworkElementBase*> nodes, QList<MyNetworkElementBase*> edges, const QString& alignType);
-
-#endif

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -15,8 +15,8 @@
 #include "negui_export_tools.h"
 #include "negui_customized_interactor_widgets.h"
 #include "negui_decorate_menu_buttons.h"
-#include "negui_element_aligner.h"
-#include "negui_element_aligner_builder.h"
+#include "negui_network_element_aligner.h"
+#include "negui_network_element_aligner_builder.h"
 
 #include <QCoreApplication>
 #include <QFileDialog>
@@ -632,7 +632,6 @@ bool MyInteractor::edgeExists(MyNetworkElementBase* n1, MyNetworkElementBase* n2
     return false;
 }
 
-#include "iostream"
 QJsonObject MyInteractor::exportNetworkInfo() {
     QJsonObject json;
 
@@ -792,10 +791,10 @@ void MyInteractor::deleteSelectedNetworkElements() {
 }
 
 void MyInteractor::alignSelectedNetworkElements(const QString& alignType) {
-    MyElementAlignerBase* elementAligner = createElementAligner(selectedNodes(), selectedEdges(), alignType);
-    if (elementAligner) {
-        elementAligner->align();
-        elementAligner->deleteLater();
+    MyNetworkElementAlignerBase* networkElementAligner = createNetworkElementAligner(selectedNodes(), selectedEdges(), alignType);
+    if (networkElementAligner) {
+        networkElementAligner->align();
+        networkElementAligner->deleteLater();
         createChangeStageCommand();
     }
 }

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -156,6 +156,7 @@ public slots:
     const bool areAnyElementsCopied();
     const bool areAnyElementsSelected();
     const QString iconsDirectoryPath();
+    QJsonObject getNetworkElementsInfo();
     
     // modes
     void enableNormalMode() override;

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -210,7 +210,7 @@ void MyNetworkEditorWidget::displayFeatureMenu(QWidget* featureMenu) {
     connect(featureMenu, SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
     removeFeatureMenu();
     ((QGridLayout*)layout())->addWidget(featureMenu, layoutMenuRow(), 2, Qt::AlignTop | Qt::AlignRight);
-    featureMenu->setFixedHeight(height());
+    featureMenu->setFixedHeight(height() - 2 * toolBar()->height() - 2 * statusBar()->height());
     _featureMenu = featureMenu;
     ((MyInteractor*)interactor())->enableDisplayFeatureMenuMode(_featureMenu->objectName());
     arrangeWidgetLayers();

--- a/src/negui_network_element_aligner.cpp
+++ b/src/negui_network_element_aligner.cpp
@@ -16,6 +16,7 @@ MyNodeAlignerBase::MyNodeAlignerBase(QList<MyNetworkElementBase*> networkElement
 void MyNodeAlignerBase::align() {
     extractExtents();
     adjustNodePositions();
+    updateNodeFocusedGraphicsItems();
 }
 
 void MyNodeAlignerBase::extractExtents() {
@@ -35,6 +36,11 @@ void MyNodeAlignerBase::extractExtents() {
             if (_maxY < position.y())
                 _maxY = position.y();
     }
+}
+
+void MyNodeAlignerBase::updateNodeFocusedGraphicsItems() {
+    for (MyNetworkElementBase* node : _networkElements)
+        ((MyNodeBase*)node)->graphicsItem()->updateFocusedGraphicsItems();
 }
 
 // MyNodeTopAligner

--- a/src/negui_network_element_aligner.cpp
+++ b/src/negui_network_element_aligner.cpp
@@ -1,15 +1,15 @@
-#include "negui_element_aligner.h"
+#include "negui_network_element_aligner.h"
 #include "negui_node.h"
 
-// MyElementAlignerBase
+// MyNetworkElementAlignerBase
 
-MyElementAlignerBase::MyElementAlignerBase(QList<MyNetworkElementBase*> elements) {
-    _elements = elements;
+MyNetworkElementAlignerBase::MyNetworkElementAlignerBase(QList<MyNetworkElementBase*> networkElements) {
+    _networkElements = networkElements;
 }
 
 // MyNodeAligner
 
-MyNodeAlignerBase::MyNodeAlignerBase(QList<MyNetworkElementBase*> elements) : MyElementAlignerBase(elements)  {
+MyNodeAlignerBase::MyNodeAlignerBase(QList<MyNetworkElementBase*> networkElements) : MyNetworkElementAlignerBase(networkElements)  {
 
 }
 
@@ -24,7 +24,7 @@ void MyNodeAlignerBase::extractExtents() {
     _maxX = INT_MIN;
     _maxY = INT_MIN;
     QPointF position;
-    for (MyNetworkElementBase* node : _elements) {
+    for (MyNetworkElementBase* node : _networkElements) {
             position = ((MyNodeBase*)node)->position();
             if (_minX > position.x())
                 _minX = position.x();
@@ -39,79 +39,79 @@ void MyNodeAlignerBase::extractExtents() {
 
 // MyNodeTopAligner
 
-MyNodeTopAligner::MyNodeTopAligner(QList<MyNetworkElementBase*> elements) : MyNodeAlignerBase(elements) {
+MyNodeTopAligner::MyNodeTopAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
 
 }
 
 void MyNodeTopAligner::adjustNodePositions() {
-    for (MyNetworkElementBase* node : _elements)
+    for (MyNetworkElementBase* node : _networkElements)
         ((MyNodeBase*)node)->graphicsItem()->moveBy(0, _minY - ((MyNodeBase*)node)->position().y());
 }
 
 // MyNodeMiddleAligner
 
-MyNodeMiddleAligner::MyNodeMiddleAligner(QList<MyNetworkElementBase*> elements) : MyNodeAlignerBase(elements) {
+MyNodeMiddleAligner::MyNodeMiddleAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
 
 }
 
 void MyNodeMiddleAligner::adjustNodePositions() {
-    for (MyNetworkElementBase* node : _elements)
+    for (MyNetworkElementBase* node : _networkElements)
         ((MyNodeBase*)node)->graphicsItem()->moveBy(0, 0.5 * (_minY + _maxY) - ((MyNodeBase*)node)->position().y());
 }
 
 // MyNodeBottomAligner
 
-MyNodeBottomAligner::MyNodeBottomAligner(QList<MyNetworkElementBase*> elements) : MyNodeAlignerBase(elements) {
+MyNodeBottomAligner::MyNodeBottomAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
 
 }
 
 void MyNodeBottomAligner::adjustNodePositions() {
-    for (MyNetworkElementBase* node : _elements)
+    for (MyNetworkElementBase* node : _networkElements)
         ((MyNodeBase*)node)->graphicsItem()->moveBy(0, _maxY - ((MyNodeBase*)node)->position().y());
 }
 
 // MyNodeLeftAligner
 
-MyNodeLeftAligner::MyNodeLeftAligner(QList<MyNetworkElementBase*> elements) : MyNodeAlignerBase(elements) {
+MyNodeLeftAligner::MyNodeLeftAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
 
 }
 
 void MyNodeLeftAligner::adjustNodePositions() {
-    for (MyNetworkElementBase* node : _elements)
+    for (MyNetworkElementBase* node : _networkElements)
         ((MyNodeBase*)node)->graphicsItem()->moveBy(_minX - ((MyNodeBase*)node)->position().x(), 0);
 }
 
 // MyNodeCenterAligner
 
-MyNodeCenterAligner::MyNodeCenterAligner(QList<MyNetworkElementBase*> elements) : MyNodeAlignerBase(elements) {
+MyNodeCenterAligner::MyNodeCenterAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
 
 }
 
 void MyNodeCenterAligner::adjustNodePositions() {
-    for (MyNetworkElementBase* node : _elements)
+    for (MyNetworkElementBase* node : _networkElements)
         ((MyNodeBase*)node)->graphicsItem()->moveBy(0.5 * (_minX + _maxX) - ((MyNodeBase*)node)->position().x(), 0);
 }
 
 // MyNodeRightAligner
 
-MyNodeRightAligner::MyNodeRightAligner(QList<MyNetworkElementBase*> elements) : MyNodeAlignerBase(elements) {
+MyNodeRightAligner::MyNodeRightAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
 
 }
 
 void MyNodeRightAligner::adjustNodePositions() {
-    for (MyNetworkElementBase* node : _elements)
+    for (MyNetworkElementBase* node : _networkElements)
         ((MyNodeBase*)node)->graphicsItem()->moveBy(_maxX - ((MyNodeBase*)node)->position().x(), 0);
 }
 
 // MyNodeDistributeAlignerBase
 
-MyNodeDistributeAlignerBase::MyNodeDistributeAlignerBase(QList<MyNetworkElementBase*> elements) : MyNodeAlignerBase(elements) {
+MyNodeDistributeAlignerBase::MyNodeDistributeAlignerBase(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
 
 }
 
 QList<MyNetworkElementBase*> MyNodeDistributeAlignerBase::getClassicNodes() {
     QList<MyNetworkElementBase*> classicNodes;
-    for (MyNetworkElementBase* node : _elements) {
+    for (MyNetworkElementBase* node : _networkElements) {
         if (((MyNodeBase*)node)->nodeType() != MyNodeBase::CENTROID_NODE)
             classicNodes.push_back(node);
     }
@@ -121,7 +121,7 @@ QList<MyNetworkElementBase*> MyNodeDistributeAlignerBase::getClassicNodes() {
 
 // MyNodeHorizontallyDistributeAligner
 
-MyNodeHorizontallyDistributeAligner::MyNodeHorizontallyDistributeAligner(QList<MyNetworkElementBase*> elements) : MyNodeDistributeAlignerBase(elements) {
+MyNodeHorizontallyDistributeAligner::MyNodeHorizontallyDistributeAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeDistributeAlignerBase(networkElements) {
 
 }
 
@@ -134,7 +134,7 @@ void MyNodeHorizontallyDistributeAligner::adjustNodePositions() {
 
 // MyNodeVerticallyDistributeAligner
 
-MyNodeVerticallyDistributeAligner::MyNodeVerticallyDistributeAligner(QList<MyNetworkElementBase*> elements) : MyNodeDistributeAlignerBase(elements) {
+MyNodeVerticallyDistributeAligner::MyNodeVerticallyDistributeAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeDistributeAlignerBase(networkElements) {
 
 }
 

--- a/src/negui_network_element_aligner.h
+++ b/src/negui_network_element_aligner.h
@@ -1,32 +1,32 @@
-#ifndef __NEGUI_ELEMENT_ALIGNER_H
-#define __NEGUI_ELEMENT_ALIGNER_H
+#ifndef __NEGUI_NETWORK_ELEMENT_ALIGNER_H
+#define __NEGUI_NETWORK_ELEMENT_ALIGNER_H
 
 #include "negui_network_element_base.h"
 
-class MyElementAlignerBase : public QObject {
+class MyNetworkElementAlignerBase : public QObject {
     Q_OBJECT
 
 public:
 
-    MyElementAlignerBase(QList<MyNetworkElementBase*> elements);
+    MyNetworkElementAlignerBase(QList<MyNetworkElementBase*> networkElements);
 
     virtual void align() = 0;
 
 protected:
 
-    QList<MyNetworkElementBase*> _elements;
+    QList<MyNetworkElementBase*> _networkElements;
     qreal _minX;
     qreal _minY;
     qreal _maxX;
     qreal _maxY;
 };
 
-class MyNodeAlignerBase : public MyElementAlignerBase {
+class MyNodeAlignerBase : public MyNetworkElementAlignerBase {
     Q_OBJECT
 
 public:
 
-    MyNodeAlignerBase(QList<MyNetworkElementBase*> elements);
+    MyNodeAlignerBase(QList<MyNetworkElementBase*> networkElements);
 
     void align() override;
 
@@ -40,7 +40,7 @@ class MyNodeTopAligner : public MyNodeAlignerBase {
 
 public:
 
-    MyNodeTopAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeTopAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };
@@ -51,7 +51,7 @@ class MyNodeMiddleAligner : public MyNodeAlignerBase {
 
 public:
 
-    MyNodeMiddleAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeMiddleAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };
@@ -62,7 +62,7 @@ class MyNodeBottomAligner : public MyNodeAlignerBase {
 
 public:
 
-    MyNodeBottomAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeBottomAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };
@@ -72,7 +72,7 @@ class MyNodeLeftAligner : public MyNodeAlignerBase {
 
 public:
 
-    MyNodeLeftAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeLeftAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };
@@ -82,7 +82,7 @@ class MyNodeCenterAligner : public MyNodeAlignerBase {
 
 public:
 
-    MyNodeCenterAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeCenterAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };
@@ -92,7 +92,7 @@ class MyNodeRightAligner : public MyNodeAlignerBase {
 
 public:
 
-    MyNodeRightAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeRightAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };
@@ -102,7 +102,7 @@ class MyNodeDistributeAlignerBase : public MyNodeAlignerBase {
 
 public:
 
-    MyNodeDistributeAlignerBase(QList<MyNetworkElementBase*> elements);
+    MyNodeDistributeAlignerBase(QList<MyNetworkElementBase*> networkElements);
 
     QList<MyNetworkElementBase*> getClassicNodes();
 };
@@ -112,7 +112,7 @@ class MyNodeHorizontallyDistributeAligner : public MyNodeDistributeAlignerBase {
 
 public:
 
-    MyNodeHorizontallyDistributeAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeHorizontallyDistributeAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };
@@ -122,7 +122,7 @@ class MyNodeVerticallyDistributeAligner : public MyNodeDistributeAlignerBase {
 
 public:
 
-    MyNodeVerticallyDistributeAligner(QList<MyNetworkElementBase*> elements);
+    MyNodeVerticallyDistributeAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
 };

--- a/src/negui_network_element_aligner.h
+++ b/src/negui_network_element_aligner.h
@@ -33,6 +33,8 @@ public:
     void extractExtents();
 
     virtual void adjustNodePositions() = 0;
+
+    void updateNodeFocusedGraphicsItems();
 };
 
 class MyNodeTopAligner : public MyNodeAlignerBase {

--- a/src/negui_network_element_aligner_builder.cpp
+++ b/src/negui_network_element_aligner_builder.cpp
@@ -1,7 +1,7 @@
-#include "negui_element_aligner_builder.h"
-#include "negui_element_aligner.h"
+#include "negui_network_element_aligner_builder.h"
+#include "negui_network_element_aligner.h"
 
-MyElementAlignerBase* createElementAligner(QList<MyNetworkElementBase*> nodes, QList<MyNetworkElementBase*> edges, const QString& alignType) {
+MyNetworkElementAlignerBase* createNetworkElementAligner(QList<MyNetworkElementBase*> nodes, QList<MyNetworkElementBase*> edges, const QString& alignType) {
     if (alignType == "Align Top")
         return new MyNodeTopAligner(nodes);
     else if (alignType == "Align Middle")

--- a/src/negui_network_element_aligner_builder.h
+++ b/src/negui_network_element_aligner_builder.h
@@ -1,0 +1,8 @@
+#ifndef __NEGUI_ELEMENT_ALIGNER_BUILDER_H
+#define __NEGUI_ELEMENT_ALIGNER_BUILDER_H
+
+#include "negui_network_element_aligner.h"
+
+MyNetworkElementAlignerBase* createNetworkElementAligner(QList<MyNetworkElementBase*> nodes, QList<MyNetworkElementBase*> edges, const QString& alignType);
+
+#endif

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -219,11 +219,6 @@ void MyNetworkElementGraphicsItemBase::setZValue(qreal z) {
     QGraphicsItemGroup::setZValue(z);
 }
 
-void MyNetworkElementGraphicsItemBase::enableNormalMode() {
-    MySceneModeElementBase::enableNormalMode();
-    clearFocusedGraphicsItems();
-}
-
 void MyNetworkElementGraphicsItemBase::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     if (event->button() == Qt::LeftButton) {
         _isChosen = true;

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -55,15 +55,13 @@ public:
     
     void setSelectedWithFillColor(const bool& selected);
 
-    void setFocused(const bool& isFocused);
+    virtual void setFocused(const bool& isFocused);
     
     void setCursor(const QCursor &cursor);
     
     void clear();
     
     void setZValue(qreal z);
-    
-    void enableNormalMode() override;
     
 signals:
     

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -35,6 +35,7 @@ MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position
     setFlag(QGraphicsItem::ItemIsFocusable, true);
     
     _reparent = false;
+    connect(this, SIGNAL(positionChangedByMouseMoveEvent()), this, SLOT(updateFocusedGraphicsItems()));
     
     setZValue(2);
 }
@@ -93,7 +94,6 @@ QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, cons
         deparent();
         moveChildItems(value.toPointF());
         emit askForResetPosition();
-        updateFocusedGraphicsItems();
     }
 
     return QGraphicsItem::itemChange(change, value);
@@ -148,13 +148,13 @@ const bool MyClassicNodeSceneGraphicsItemBase::canAddTextShape() {
     return true;
 }
 
-void MyClassicNodeSceneGraphicsItemBase::clearFocusedGraphicsItems() {
-    if (_focusedGraphicsItems.size()) {
+void MyClassicNodeSceneGraphicsItemBase::setFocused(const bool& isFocused) {
+    if (!isFocused && _focusedGraphicsItems.size()) {
         emit askForResetPosition();
         adjustOriginalPosition();
         emit askForCreateChangeStageCommand();
     }
-    MyNetworkElementGraphicsItemBase::clearFocusedGraphicsItems();
+    MyNetworkElementGraphicsItemBase::setFocused(isFocused);
 }
 
 void MyClassicNodeSceneGraphicsItemBase::moveBy(qreal dx, qreal dy) {

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -84,7 +84,7 @@ public:
 
     const bool canAddTextShape() override;
 
-    void clearFocusedGraphicsItems() override;
+    void setFocused(const bool& isFocused) override;
 
     void moveBy(qreal dx, qreal dy);
 


### PR DESCRIPTION
Undo action and focused graphics items of the nodes are handled.

- when a node is unfocused its graphics item is updated based on its focused graphics item features
- only when a node is moved by the user clicking and dragging it, its focused graphics items are updated
- align function of Node Aligner class calls update node focused graphics item function so that the focused graphics item of the aligned nodes become updated
This PR fixes #57 issue