### PR TITLE
Displaying feature menu situation is updated

### DIFF
--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -1034,7 +1034,7 @@ void MyInteractor::autoLayout(MyPluginItemBase* autoLayoutEngine) {
     if (!((MyAutoLayoutEngine*)autoLayoutEngine)->takeParameters()) {
         QJsonObject autoLayoutInfoObject;
         autoLayoutEngine->write(autoLayoutInfoObject);
-        QJsonObject graphInfoObject = getNetworkElementsInfo();
+        QJsonObject graphInfoObject = exportNetworkInfo();
         autoLayoutInterface()->autoLayout(graphInfoObject, autoLayoutInfoObject);
         createNetwork(graphInfoObject);
         createChangeStageCommand();


### PR DESCRIPTION
- items are now kept movable while display feature menu mode is activated

- if display feature menu mode is already activated, the feature menu for an item will be shown by single clicking on it

- no delay is applied in displaying feature menu anymore

- display feature menu function in the main widget is rearranged to make sure the order of events is right

This PR fixes #44 issue