### PR TITLE
Displaying feature menu situation is updated

### DIFF
--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -724,13 +724,11 @@ void MyInteractor::selectElement(MyNetworkElementBase* element) {
         emit elementsCuttableStatusChanged(areSelectedElementsCuttable());
         emit elementsCopyableStatusChanged(areSelectedElementsCopyable());
     }
-}
-
-void MyInteractor::unselectElement(MyNetworkElementBase* element) {
-    if (getSceneMode() == NORMAL_MODE) {
-        element->setSelected(false);
-        emit elementsCuttableStatusChanged(areSelectedElementsCuttable());
-        emit elementsCopyableStatusChanged(areSelectedElementsCopyable());
+    else if (getSceneMode() == DISPLAY_FEATURE_MENU_MODE) {
+        if (!element->isSelected()) {
+            selectElements(false);
+            element->setSelected(true);
+        }
     }
 }
 

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -138,7 +138,6 @@ public slots:
     const QList<MyNetworkElementBase*> selectedNodes();
     const QList<MyNetworkElementBase*> selectedEdges();
     void selectElement(MyNetworkElementBase* element);
-    void unselectElement(MyNetworkElementBase* element);
     void selectElement(const QString& elementName);
     void selectElements(const bool& selected);
     void selectElements(const bool& selected, const QString& category);

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -207,13 +207,13 @@ const qreal& MyNetworkEditorWidget::layoutMenuRow() {
 }
 
 void MyNetworkEditorWidget::displayFeatureMenu(QWidget* featureMenu) {
-    connect(featureMenu, SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
     removeFeatureMenu();
-    ((QGridLayout*)layout())->addWidget(featureMenu, layoutMenuRow(), 2, Qt::AlignTop | Qt::AlignRight);
+    ((MyInteractor*)interactor())->enableDisplayFeatureMenuMode(featureMenu->objectName());
     featureMenu->setFixedHeight(height() - 2 * toolBar()->height() - 2 * statusBar()->height());
-    _featureMenu = featureMenu;
-    ((MyInteractor*)interactor())->enableDisplayFeatureMenuMode(_featureMenu->objectName());
+    ((QGridLayout*)layout())->addWidget(featureMenu, layoutMenuRow(), 2, Qt::AlignTop | Qt::AlignRight);
     arrangeWidgetLayers();
+    _featureMenu = featureMenu;
+    connect(_featureMenu, SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
 }
 
 void MyNetworkEditorWidget::removeFeatureMenu() {

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -2,7 +2,6 @@
 #include "negui_feature_menu.h"
 
 #include <QGridLayout>
-#include <QTimer>
 
 // MyNetworkElementBase
 
@@ -61,7 +60,7 @@ void MyNetworkElementBase::updateStyle(QList<MyShapeStyleBase*> shapeStyles) {
 const QString MyNetworkElementBase::styleCategory() {
     if (!style()->category().isEmpty())
         return style()->category();
-    
+
     return "N/A";
 }
 
@@ -117,14 +116,14 @@ void MyNetworkElementBase::enableDisplayFeatureMenuMode() {
 QWidget* MyNetworkElementBase::getFeatureMenu() {
     MyFeatureMenuItemFrame* featureMenu = new MyFeatureMenuItemFrame();
     QGridLayout* contentLayout = (QGridLayout*)featureMenu->layout();
-    
+
     // title
     contentLayout->addWidget(new MyTitleLabel(styleCategory()), contentLayout->rowCount(), 0, 1, 2, Qt::AlignCenter);
-    
+
     // spacer
     QLayoutItem* spacerItem = new MySpacerItem(0, 10);
     contentLayout->addItem(spacerItem, contentLayout->rowCount(), 0, 1, 2);
-    
+
     // name
     QString nameTitle = "Name";
     if (!style()->nameTitle().isEmpty())
@@ -156,13 +155,6 @@ void MyNetworkElementBase::createFeatureMenu() {
             updateGraphicsItem();
             updateFocusedGraphicsItems();
             emit askForCreateChangeStageCommand(); } );
-        askForDisplayFeatureMenuWithDelay(featureMenu, 200);
+        askForDisplayFeatureMenu(featureMenu);
     }
-}
-
-void MyNetworkElementBase::askForDisplayFeatureMenuWithDelay(QWidget* featureMenu, const qint32 delayTime) {
-    QTimer* timer = new QTimer();
-    timer->setSingleShot(true);
-    connect(timer, &QTimer::timeout, this, [this, featureMenu] () { askForDisplayFeatureMenu(featureMenu); } );
-    timer->start(delayTime);
 }

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -69,8 +69,6 @@ public:
     
     virtual const qint32 calculateZValue() = 0;
 
-    void askForDisplayFeatureMenuWithDelay(QWidget* featureMenu, const qint32 delayTime);
-
     signals:
     
     void askForSelectNetworkElement(MyNetworkElementBase*);

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -11,6 +11,10 @@ MyNetworkElementGraphicsItemBase::MyNetworkElementGraphicsItemBase(QGraphicsItem
     _originalPosition = QPointF(0.0, 0.0);
     connect(this, SIGNAL(mouseLeftButtonIsPressed()), this, SIGNAL(askForSelectNetworkElement()));
     connect(this, SIGNAL(mouseLeftButtonIsDoubleClicked()), this, SIGNAL(askForCreateFeatureMenu()));
+    connect(this, &MyNetworkElementGraphicsItemBase::mouseLeftButtonIsPressed, this, [this] () {
+        if (getSceneMode() == DISPLAY_FEATURE_MENU_MODE)
+            askForCreateFeatureMenu();
+    });
 }
 
 void MyNetworkElementGraphicsItemBase::update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) {

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -86,7 +86,6 @@ void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
 void MyNodeSceneGraphicsItemBase::enableDisplayFeatureMenuMode() {
     MyNetworkElementGraphicsItemBase::enableDisplayFeatureMenuMode();
     setCursor(Qt::PointingHandCursor);
-    setFlag(QGraphicsItem::ItemIsMovable, false);
 }
 
 QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, const QVariant &value) {


### PR DESCRIPTION
- items are now kept movable while display feature menu mode is activated

- if display feature menu mode is already activated, the feature menu for an item will be shown by single clicking on it

- no delay is applied in displaying feature menu anymore

- display feature menu function in the main widget is rearranged to make sure the order of events is right

This PR fixes #44 issue