### PR TITLE
Simple Text Style extents is now connected to the shape assoicated with it

### DIFF
--- a/src/negui_centroid_style.cpp
+++ b/src/negui_centroid_style.cpp
@@ -15,6 +15,10 @@ const QRectF MyCentroidStyleBase::getShapeExtents() {
     return QRectF(0.0, 0.0, 2 * radius(), 2 * radius());
 }
 
+void MyCentroidStyleBase::updateShapeExtents(const QRectF& extents) {
+    setRadius(0.5 * (extents.width() + extents.height()));
+}
+
 void MyCentroidStyleBase::setRadius(const qreal& radius) const {
     MyParameterBase* parameter = findParameter("radius");
     if (parameter)

--- a/src/negui_centroid_style.h
+++ b/src/negui_centroid_style.h
@@ -4,25 +4,31 @@
 #include "negui_2d_shape_style_base.h"
 
 class MyCentroidStyleBase : public My2DShapeStyleBase {
+    Q_OBJECT
+
 public:
-    
+
     MyCentroidStyleBase(const QString& name);
-    
+
     SHAPE_STYLE type() override;
-    
+
     const QRectF getShapeExtents() override;
 
     // set the value of radius
     void setRadius(const qreal& rx) const;
-    
+
     // get the value of radius
     const qreal radius() const;
-    
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
-    
+
     // write the node style info to the json object
     void write(QJsonObject &json) override;
+
+public slots:
+
+    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodeCentroidStyle : public MyCentroidStyleBase {

--- a/src/negui_ellipse_style.cpp
+++ b/src/negui_ellipse_style.cpp
@@ -36,6 +36,13 @@ const QRectF MyEllipseStyleBase::getShapeExtents() {
     return extents;
 }
 
+void MyEllipseStyleBase::updateShapeExtents(const QRectF& extents) {
+    setCx(extents.center().x());
+    setCy(extents.center().y());
+    setRx(0.5 * extents.width());
+    setRy(0.5 * extents.height());
+}
+
 void MyEllipseStyleBase::setCx(const qreal& cx) const {
     MyParameterBase* parameter = findParameter("cx");
     if (parameter)

--- a/src/negui_ellipse_style.h
+++ b/src/negui_ellipse_style.h
@@ -4,43 +4,49 @@
 #include "negui_2d_shape_style_base.h"
 
 class MyEllipseStyleBase : public My2DShapeStyleBase {
+    Q_OBJECT
+
 public:
-    
+
     MyEllipseStyleBase(const QString& name);
-    
+
     SHAPE_STYLE type() override;
-    
+
     const QRectF getShapeExtents() override;
-    
+
     // set the cx value of center position
     void setCx(const qreal& cx) const;
-    
+
     // get the x value of center position
     const qreal cx() const;
-    
+
     // set the cy value of center position
     void setCy(const qreal& cy) const;
-    
+
     // get the y value of center position
     const qreal cy() const;
-    
+
     // set the value of horizontal radius
     void setRx(const qreal& rx) const;
-    
+
     // get the value of horizontal radius
     const qreal rx() const;
-    
+
     // set the value of vertical radius
     void setRy(const qreal& rx) const;
-    
+
     // get the value of vertical radius
     const qreal ry() const;
-    
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
-    
+
     // write the node style info to the json object
     void write(QJsonObject &json) override;
+
+public slots:
+
+    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodeEllipseStyle : public MyEllipseStyleBase {

--- a/src/negui_line_style.cpp
+++ b/src/negui_line_style.cpp
@@ -27,6 +27,10 @@ const QRectF MyLineStyleBase::getShapeExtents() {
     return QRectF(0.0, 0.0, 0.0, 0.0);
 }
 
+void MyLineStyleBase::updateShapeExtents(const QRectF& extents) {
+
+}
+
 void MyLineStyleBase::setRelativeP1(const QPointF& relativeP1) const {
     QPoint point;
     MyParameterBase* parameter = findParameter("ControlPoint1");

--- a/src/negui_line_style.h
+++ b/src/negui_line_style.h
@@ -4,6 +4,8 @@
 #include "negui_1d_shape_style_base.h"
 
 class MyLineStyleBase : public My1DShapeStyleBase {
+    Q_OBJECT
+
 public:
 
     typedef enum {
@@ -11,32 +13,36 @@ public:
         CONNECTED_TO_START_CENTROID_SHAPE_LINE_STYLE,
         CONNECTED_TO_END_CENTROID_SHAPE_LINE_STYLE,
     } LINE_STYLE_TYPE;
-    
+
     MyLineStyleBase(const QString& name);
-    
+
     SHAPE_STYLE type() override;
 
     virtual LINE_STYLE_TYPE lineType() = 0;
-    
+
     const QRectF getShapeExtents() override;
-    
+
     // set the relative value of p1
     void setRelativeP1(const QPointF& relativeP1) const;
-    
+
     // get the relative value of p1
     const QPoint relativeP1() const;
-    
+
     // set the relative value of p2
     void setRelativeP2(const QPointF& relativeP2) const;
-    
+
     // get the relative value of p2
     const QPoint relativeP2() const;
-    
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
-    
+
     // write the node style info to the json object
     void write(QJsonObject &json) override;
+
+public slots:
+
+    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyClassicLineStyle : public MyLineStyleBase {

--- a/src/negui_network_element_style_base.h
+++ b/src/negui_network_element_style_base.h
@@ -45,7 +45,7 @@ public:
     
 public slots:
     
-    void setShapeStyles(QList<MyShapeStyleBase*> shapeStyles);
+    virtual void setShapeStyles(QList<MyShapeStyleBase*> shapeStyles);
     
 protected:
     QList<MyShapeStyleBase*> _shapeStyles;

--- a/src/negui_node_style.cpp
+++ b/src/negui_node_style.cpp
@@ -121,6 +121,26 @@ MyShapeStyleBase* MySimpleClassicNodeStyle::createShapeStyle(const QString& shap
     return NULL;
 }
 
+void MySimpleClassicNodeStyle::setShapeStyles(QList<MyShapeStyleBase*> shapeStyles) {
+    MyNetworkElementStyleBase::setShapeStyles(shapeStyles);
+    updateSimpleTextStyleExtentsWithOtherShapeStyleExtents();
+}
+
+void MySimpleClassicNodeStyle::updateSimpleTextStyleExtentsWithOtherShapeStyleExtents() {
+    if (shapeStyles().size() == 2) {
+        MyShapeStyleBase* simpleTextStyle = NULL;
+        MyShapeStyleBase* otherShapeStyle = NULL;
+        for (MyShapeStyleBase* shapeStyle : shapeStyles()) {
+            if (shapeStyle->type() == MyShapeStyleBase::SIMPLE_TEXT_SHAPE_STYLE)
+                simpleTextStyle = shapeStyle;
+            else
+                otherShapeStyle = shapeStyle;
+        }
+        if (simpleTextStyle && otherShapeStyle)
+            simpleTextStyle->updateShapeExtents(otherShapeStyle->getShapeExtents());
+    }
+}
+
 QWidget* MySimpleClassicNodeStyle::shapeStylesButtons() {
     QWidget* shapeStylesButtons = new MyChangeNodeShapeStylesButton();
     ((MyChangeNodeShapeStylesButton*)shapeStylesButtons)->setMenu();

--- a/src/negui_node_style.h
+++ b/src/negui_node_style.h
@@ -63,6 +63,8 @@ protected:
 };
 
 class MySimpleClassicNodeStyle : public MyClassicNodeStyleBase {
+    Q_OBJECT
+
 public:
 
     MySimpleClassicNodeStyle(const QString& name);
@@ -71,11 +73,17 @@ public:
 
     MyShapeStyleBase* createShapeStyle(const QString& shape) override;
 
+    void updateSimpleTextStyleExtentsWithOtherShapeStyleExtents();
+
     QWidget* shapeStylesButtons() override;
 
     const bool whetherAnotherGeometricShapeAlreadyExists();
 
     const bool whetherAnotherTextShapeAlreadyExists();
+
+public slots:
+
+    void setShapeStyles(QList<MyShapeStyleBase*> shapeStyles) override;
 };
 
 class MyComplexClassicNodeStyle : public MyClassicNodeStyleBase {

--- a/src/negui_polygon_style.cpp
+++ b/src/negui_polygon_style.cpp
@@ -60,6 +60,10 @@ const QRectF MyPolygonStyleBase::getShapeExtents() {
     return extents;
 }
 
+void MyPolygonStyleBase::updateShapeExtents(const QRectF& extents) {
+    scaleToExtents(extents);
+}
+
 void MyPolygonStyleBase::scaleToExtents(const QRectF& extents) {
     QRectF polygonBoundingRect = getShapeExtents();
     qreal xScaleFactor = extents.width() / polygonBoundingRect.width();

--- a/src/negui_polygon_style.h
+++ b/src/negui_polygon_style.h
@@ -4,36 +4,42 @@
 #include "negui_2d_shape_style_base.h"
 
 class MyPolygonStyleBase : public My2DShapeStyleBase {
+    Q_OBJECT
+
 public:
-    
+
     MyPolygonStyleBase(const QString& name);
-    
+
     SHAPE_STYLE type() override;
-    
+
     const QRectF getShapeExtents() override;
-    
+
     // get the list of point parameters
     const QList<MyAbsolutePointParameter*> pointParameters() const;
-    
+
     // get the list of points
     const QList<QPointF> points() const;
-    
+
     // scale the points to fit the extents
-    void scaleToExtents(const QRectF& extetns);
-    
+    void scaleToExtents(const QRectF& extents);
+
     void moveBy(qreal dx, qreal dy);
-    
+
     // add the default points for a polygon style that contains no point
     virtual void addDefaultPoints() = 0;
-    
+
     // reset all the values
     void reset() override;
-    
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
-    
+
     // write the node style info to the json object
     void write(QJsonObject &json) override;
+
+public slots:
+
+    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodePolygonStyle : public MyPolygonStyleBase {

--- a/src/negui_rectangle_style.cpp
+++ b/src/negui_rectangle_style.cpp
@@ -42,6 +42,13 @@ const QRectF MyRectangleStyleBase::getShapeExtents() {
     return extents;
 }
 
+void MyRectangleStyleBase::updateShapeExtents(const QRectF& extents) {
+    setX(extents.x());
+    setY(extents.y());
+    setWidth(extents.width());
+    setHeight(extents.height());
+}
+
 void MyRectangleStyleBase::setX(const qreal& x) const {
     MyParameterBase* parameter = findParameter("x");
     if (parameter)

--- a/src/negui_rectangle_style.h
+++ b/src/negui_rectangle_style.h
@@ -4,55 +4,61 @@
 #include "negui_2d_shape_style_base.h"
 
 class MyRectangleStyleBase : public My2DShapeStyleBase {
+    Q_OBJECT
+
 public:
-    
+
     MyRectangleStyleBase(const QString& name);
-    
+
     SHAPE_STYLE type() override;
-    
+
     const QRectF getShapeExtents() override;
-    
+
     // set the x value of position
     void setX(const qreal& x) const;
-    
+
     // get the x value of position
     const qreal x() const;
-    
+
     // set the y value of position
     void setY(const qreal& y) const;
-    
+
     // get the y value of position
     const qreal y() const;
-    
+
     // set the value of width
     void setWidth(const qreal& width) const;
-    
+
     // get the value of width
     const qreal width() const;
-    
+
     // set the value of height
     void setHeight(const qreal& height) const;
-    
+
     // get the value of height
     const qreal height() const;
-    
+
     // set the x value of corner radius
     void setRx(const qreal& rx) const;
-    
+
     // get the x value of corner radius
     const qreal rx() const;
-    
+
     // set the y value of corner radius
     void setRy(const qreal& ry) const;
-    
+
     // get the y value of corner radius
     const qreal ry() const;
-    
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
-    
+
     // write the node style info to the json object
     void write(QJsonObject &json) override;
+
+public slots:
+
+    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodeRectangleStyle : public MyRectangleStyleBase {

--- a/src/negui_shape_style_base.h
+++ b/src/negui_shape_style_base.h
@@ -64,6 +64,10 @@ signals:
 
     void isUpdated();
 
+public slots:
+
+    virtual void updateShapeExtents(const QRectF& extents) = 0;
+
 protected:
     QList<MyParameterBase*> _parameters;
     QList<MyParameterBase*> _outsourcingParameters;

--- a/src/negui_text_style.cpp
+++ b/src/negui_text_style.cpp
@@ -69,6 +69,13 @@ const QRectF MyTextStyleBase::getShapeExtents() {
     return extents;
 }
 
+void MyTextStyleBase::updateShapeExtents(const QRectF& extents) {
+    setX(extents.x());
+    setY(extents.y());
+    setWidth(extents.width());
+    setHeight(extents.height());
+}
+
 void MyTextStyleBase::setX(const qreal& x) const {
     MyParameterBase* parameter = findParameter("x");
     if (parameter)

--- a/src/negui_text_style.h
+++ b/src/negui_text_style.h
@@ -4,8 +4,10 @@
 #include "negui_2d_shape_style_base.h"
 
 class MyTextStyleBase : public My2DShapeStyleBase {
+    Q_OBJECT
+
 public:
-    
+
     MyTextStyleBase(const QString& name);
 
     // get the plain text for text
@@ -13,52 +15,56 @@ public:
 
     // set the plain text for text
     void setPlainText(const QString& plainText);
-    
+
     const QRectF getShapeExtents() override;
-    
+
     // get the default color for text
     const QColor defaultTextColor() const;
-    
+
     // get the font for text
     const QFont font() const;
-    
+
     // set the x value of position
     void setX(const qreal& x) const;
-    
+
     // get the x value of position
     const qreal x() const;
-    
+
     // set the y value of position
     void setY(const qreal& y) const;
-    
+
     // get the y value of position
     const qreal y() const;
-    
+
     // set the value of width
     void setWidth(const qreal& width) const;
-    
+
     // get the value of width
     const qreal width() const;
-    
+
     // set the value of height
     void setHeight(const qreal& height) const;
-    
+
     // get the value of text height
     const qreal height() const;
-    
+
     // get the horizontal alignment of text
     const Qt::Alignment horizontalAlignment() const;
-    
+
     // get the vertical alignment of text
     const Qt::Alignment verticalAlignment() const;
-    
+
     const qreal verticalPadding() const;
 
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
-    
+
     // write the node style info to the json object
     void write(QJsonObject &json) override;
+
+public slots:
+
+    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MySimpleTextStyle : public MyTextStyleBase {


### PR DESCRIPTION
The extetns of the simple text style, which is used for simple node graphics items, is now set to equal to the extetns of the other shape style associated with it in real-time. This completes the #65  PR and fixes #42 issue