### PR TITLE
The expanded branch of the shape style is kept exapnded if the feature menu with the same branches is displayed for another element

### DIFF
--- a/src/negui_customized_feature_menu_widgets.h
+++ b/src/negui_customized_feature_menu_widgets.h
@@ -151,11 +151,17 @@ public:
 
     void removeBranches(const QString& rootTitle= "", const unsigned int& staticbranches = 0);
 
+    void expandBranch(MyShapeStyleBase* shapeStyle);
+
+    void expandBranch(const qint32& branchIndex);
+
     void expandFirstBranch();
 
     void expandLastBranch();
 
     const QSize collapsedSize() const;
+
+    const QString getExpandedBranchTitle();
 
 signals:
 
@@ -163,7 +169,6 @@ signals:
 
 protected:
 
-    QStandardItemModel* treeModel;
     branchVec _branches;
 };
 

--- a/src/negui_feature_menu.cpp
+++ b/src/negui_feature_menu.cpp
@@ -81,6 +81,21 @@ void MyFeatureMenu::changeShapeStyle(MyShapeStyleBase* shapeStyle) {
     emit isUpdated(shapeStyles());
 }
 
+MyShapeStyleBase* MyFeatureMenu::beingModifiedShapeStyle() {
+    QString expandedBranchTitle = ((MyShapeStyleTreeView*)_shapeStylesTreeView)->getExpandedBranchTitle();
+    for (MyShapeStyleBase* shapeStyle : shapeStyles()) {
+        if (shapeStyle->name() == expandedBranchTitle)
+            return shapeStyle;
+    }
+
+    return NULL;
+}
+
+void MyFeatureMenu::setBeingModifiedShapeStyle(MyShapeStyleBase* shapeStyle) {
+    if (shapeStyle)
+        ((MyShapeStyleTreeView*)_shapeStylesTreeView)->expandBranch(shapeStyle);
+}
+
 void MyFeatureMenu::clearShapeStyles() {
     while(shapeStyles().size())
         delete shapeStyles().takeLast();

--- a/src/negui_feature_menu.h
+++ b/src/negui_feature_menu.h
@@ -19,6 +19,10 @@ public:
 
     void addSingleShapeStyle(MyShapeStyleBase* shapeStyle);
 
+    MyShapeStyleBase* beingModifiedShapeStyle();
+
+    void setBeingModifiedShapeStyle(MyShapeStyleBase* shapeStyle);
+
     void clearShapeStyles();
 
 signals:

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -292,7 +292,7 @@ void MyInteractor::addNode(MyNetworkElementBase* n) {
         connect(n, SIGNAL(askForDeleteNetworkElement(MyNetworkElementBase*)), this, SLOT(deleteNode(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
         connect(n, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
-        connect(n, SIGNAL(askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)), this, SIGNAL(askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)));
+        connect(n, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
         connect(n, SIGNAL(askForCheckWhetherNetworkElementNameIsAlreadyUsed(const QString&)), this, SLOT(isElementNameAlreadyUsed(const QString&)));
         connect(n, SIGNAL(askForCopyNetworkElement(MyNetworkElementBase*)), this, SLOT(setCopiedNode(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForCutNetworkElement(MyNetworkElementBase*)), this, SLOT(setCutNode(MyNetworkElementBase*)));
@@ -430,6 +430,7 @@ void MyInteractor::addEdge(MyNetworkElementBase* e) {
         connect(e, SIGNAL(askForDeleteNetworkElement(MyNetworkElementBase*)), this, SLOT(deleteEdge(MyNetworkElementBase*)));
         connect(e, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
         connect(e, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
+        connect(e, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
         connect(e, SIGNAL(askForCheckWhetherNetworkElementNameIsAlreadyUsed(const QString&)), this, SLOT(isElementNameAlreadyUsed(const QString&)));
         connect(e, SIGNAL(askForCopyNetworkElementStyle(MyNetworkElementStyleBase*)), this, SLOT(setCopiedEdgeStyle(MyNetworkElementStyleBase*)));
         connect(e, SIGNAL(askForPasteNetworkElementStyle(MyNetworkElementBase*)), this, SLOT(pasteCopiedEdgeStyle(MyNetworkElementBase*)));

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -103,7 +103,7 @@ signals:
     void askForSetToolTip(const QString& toolTip);
     void askForDisplayFeatureMenu(QWidget*);
     void askForRemoveFeatureMenu();
-    const bool askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&);
+    QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
     void modeIsSet(const QString&);
     void currentFileNameIsUpdated(const QString&);

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -83,7 +83,7 @@ void MyNetworkEditorWidget::setInteractions() {
     // display feature menu
     connect((MyInteractor*)interactor(), SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SLOT(displayFeatureMenu(QWidget*)));
     connect((MyInteractor*)interactor(), SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
-    connect((MyInteractor*)interactor(), SIGNAL(askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)), this, SLOT(whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&)));
+    connect((MyInteractor*)interactor(), &MyInteractor::askForCurrentlyBeingDisplayedNetworkElementFeatureMenu, this, [this] () { return featureMenu(); } );
 
     /// mode menu
     // set mode
@@ -224,13 +224,6 @@ void MyNetworkEditorWidget::removeFeatureMenu() {
     }
     if (((MyInteractor*)interactor())->getSceneMode() == MySceneModeElementBase::DISPLAY_FEATURE_MENU_MODE)
         ((MyInteractor*)interactor())->enableNormalMode();
-}
-
-const bool MyNetworkEditorWidget::whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString& elementName) {
-    if (featureMenu() && featureMenu()->objectName() == elementName)
-        return true;
-
-    return false;
 }
 
 void MyNetworkEditorWidget::setReadyToLaunch() {

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -50,10 +50,9 @@ private slots:
 
     void displayFeatureMenu(QWidget* featureMenu);
     void removeFeatureMenu();
-    const bool whetherNetworkElementFeatureMenuIsBeingDisplayed(const QString& elementName);
 
 protected:
-    
+
     void setWidgets();
     void setInteractions();
     void arrangeWidgetLayers();

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -146,15 +146,27 @@ QWidget* MyNetworkElementBase::getFeatureMenu() {
 }
 
 void MyNetworkElementBase::createFeatureMenu() {
-    if ((getSceneMode() == NORMAL_MODE || getSceneMode() == DISPLAY_FEATURE_MENU_MODE) && !askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(name())) {
-        MyFeatureMenu* featureMenu =  new MyFeatureMenu(getFeatureMenu(), askForIconsDirectoryPath());
-        featureMenu->setObjectName(name());
-        featureMenu->setShapeStyles(style()->shapeStyles());
-        connect(featureMenu, &MyFeatureMenu::isUpdated, this, [this] (QList<MyShapeStyleBase*> shapeStyles) {
-            updateStyle(shapeStyles);
-            updateGraphicsItem();
-            updateFocusedGraphicsItems();
-            emit askForCreateChangeStageCommand(); } );
-        askForDisplayFeatureMenu(featureMenu);
+    if ((getSceneMode() == NORMAL_MODE || getSceneMode() == DISPLAY_FEATURE_MENU_MODE)) {
+        QWidget* currentFeatureMenu = askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
+        if (!currentFeatureMenu || currentFeatureMenu->objectName() != name()) {
+            QWidget* featureMenu = createAndConnectFeatureMenuObject();
+            if (currentFeatureMenu)
+                ((MyFeatureMenu*)featureMenu)->setBeingModifiedShapeStyle(((MyFeatureMenu*)currentFeatureMenu)->beingModifiedShapeStyle());
+            askForDisplayFeatureMenu(featureMenu);
+        }
     }
+}
+
+QWidget* MyNetworkElementBase::createAndConnectFeatureMenuObject() {
+    MyFeatureMenu* featureMenu =  new MyFeatureMenu(getFeatureMenu(), askForIconsDirectoryPath());
+    featureMenu->setObjectName(name());
+    featureMenu->setShapeStyles(style()->shapeStyles());
+    connect(featureMenu, &MyFeatureMenu::isUpdated, this, [this] (QList<MyShapeStyleBase*> shapeStyles) {
+        updateStyle(shapeStyles);
+        updateGraphicsItem();
+        updateFocusedGraphicsItems();
+        emit askForCreateChangeStageCommand(); } );
+
+    return featureMenu;
+
 }

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -69,6 +69,8 @@ public:
     
     virtual const qint32 calculateZValue() = 0;
 
+    QWidget* createAndConnectFeatureMenuObject();
+
     signals:
     
     void askForSelectNetworkElement(MyNetworkElementBase*);

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -77,7 +77,7 @@ public:
 
     void askForDisplayFeatureMenu(QWidget*);
 
-    const bool askForWhetherNetworkElementFeatureMenuIsBeingDisplayed(const QString&);
+    QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
 
     void askForCopyNetworkElement(MyNetworkElementBase*);
 


### PR DESCRIPTION
the shape style of the expanded branch of the currently being displayed feature menu is extracted from that menu and is passed to the newly created feature menu so that it expands a branch with the same shape style type if that shape style exists in the list of its branches

This PR fixes #46 issue