### PR TITLE
Distributre node on grid is added

### DIFF
--- a/src/negui_context_menu.cpp
+++ b/src/negui_context_menu.cpp
@@ -39,6 +39,7 @@ MyGraphicsSceneContextMenu::MyGraphicsSceneContextMenu(QWidget *parent) : MyCont
     alignMenu->addSeparator();
     connect(alignMenu->addAction("Distribute Horizontally"), &QAction::triggered, [this] () { emit askForAlignSelectedNetworkElements("Distribute Horizontally"); });
     connect(alignMenu->addAction("Distribute Vertically"), &QAction::triggered, [this] () { emit askForAlignSelectedNetworkElements("Distribute Vertically"); });
+    connect(alignMenu->addAction("Distribute on Grid"), &QAction::triggered, [this] () { emit askForAlignSelectedNetworkElements("Distribute on Grid"); });
 }
 
 void MyGraphicsSceneContextMenu::initializeActionsStatus() {

--- a/src/negui_network_element_aligner.h
+++ b/src/negui_network_element_aligner.h
@@ -2,6 +2,7 @@
 #define __NEGUI_NETWORK_ELEMENT_ALIGNER_H
 
 #include "negui_network_element_base.h"
+#include "negui_customized_common_widgets.h"
 
 class MyNetworkElementAlignerBase : public QObject {
     Q_OBJECT
@@ -127,6 +128,28 @@ public:
     MyNodeVerticallyDistributeAligner(QList<MyNetworkElementBase*> networkElements);
 
     void adjustNodePositions() override;
+};
+
+class MyNodeGridDistributeAligner : public MyNodeDistributeAlignerBase {
+    Q_OBJECT
+
+public:
+
+    MyNodeGridDistributeAligner(QList<MyNetworkElementBase*> networkElements);
+
+    void adjustNodePositions() override;
+
+    qint32 getNumberOfGridColumns(QList<MyNetworkElementBase*> classicNodes);
+
+    void adjustClassicNodesPositionsInGrid(QList<MyNetworkElementBase*> classicNodes, const qint32& numberOfGridColumns);
+};
+
+class MyGetNumberOfGridColumnsDialog : public MyDialog {
+    Q_OBJECT
+
+public:
+
+    MyGetNumberOfGridColumnsDialog(MyParameterBase* parameter, QWidget *parent = nullptr);
 };
 
 

--- a/src/negui_network_element_aligner_builder.cpp
+++ b/src/negui_network_element_aligner_builder.cpp
@@ -18,6 +18,8 @@ MyNetworkElementAlignerBase* createNetworkElementAligner(QList<MyNetworkElementB
         return new MyNodeHorizontallyDistributeAligner(nodes);
     else if (alignType == "Distribute Vertically")
         return new MyNodeVerticallyDistributeAligner(nodes);
+    else if (alignType == "Distribute on Grid")
+        return new MyNodeGridDistributeAligner(nodes);
 
     return NULL;
 }

--- a/src/negui_parameters.cpp
+++ b/src/negui_parameters.cpp
@@ -1025,3 +1025,17 @@ const Qt::Alignment MyVerticalAlignmentParameter::defaultAlignment() const {
 void MyVerticalAlignmentParameter::reset() {
     setDefaultValue("middle");
 }
+
+MyNodeDistributionNumberOfGridColumnsParameter::MyNodeDistributionNumberOfGridColumnsParameter(const qint32 numberOfSelectedNodes) : MyIntegerParameter("Number of Grid Columns") {
+    _numberOfSelectedNodes = numberOfSelectedNodes;
+    reset();
+}
+
+void MyNodeDistributionNumberOfGridColumnsParameter::reset() {
+    setMin(1);
+    setMax(_numberOfSelectedNodes);
+    setStep(1);
+    setDefaultValue(1);
+    if (_numberOfSelectedNodes >= 2)
+        setDefaultValue(qint32(0.5 * _numberOfSelectedNodes));
+}

--- a/src/negui_parameters.h
+++ b/src/negui_parameters.h
@@ -734,4 +734,16 @@ public:
     void reset() override;
 };
 
+class MyNodeDistributionNumberOfGridColumnsParameter : public MyIntegerParameter {
+public:
+
+    MyNodeDistributionNumberOfGridColumnsParameter(const qint32 numberOfSelectedNodes);
+
+    // reset the values of the parameter
+    void reset() override;
+
+protected:
+    qint32 _numberOfSelectedNodes;
+};
+
 #endif


### PR DESCRIPTION
 -distribute on Grid option is added on the align submenu of the right click menu
- node distribution parameter is introduced
-  node grid distribute aligner class
- network element aligner builder now can create an object of the class node grid distribute aligner

This PR along with #31 PR fixes #11 issue