### PR TITLE
Select a group of nodes feature is added and some bugs are fixed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(source_files
 		negui_new_edge_builder.cpp
 		negui_network_element_aligner.cpp
 		negui_network_element_aligner_builder.cpp
+		negui_network_element_mover.cpp
 		negui_selection_area_graphics_item.cpp
 		negui_network_element_style_base.cpp
 		negui_template_style.cpp
@@ -105,6 +106,7 @@ set(header_files
 		negui_new_edge_builder.h
 		negui_network_element_aligner.h
 		negui_network_element_aligner_builder.h
+		negui_network_element_mover.h
 		negui_selection_area_graphics_item.h
 		negui_network_element_style_base.h
 		negui_template_style.h

--- a/src/negui_arrow_head.cpp
+++ b/src/negui_arrow_head.cpp
@@ -62,6 +62,15 @@ void MyArrowHeadBase::setSelectedWithColor(const bool& selected) {
         graphicsItem()->setSelectedWithFillColor(selected);
 }
 
+const bool MyArrowHeadBase::canBeMovedExternally() {
+    return false;
+}
+
+void MyArrowHeadBase::moveExternally(const qreal& dx, const qreal& dy) {
+    if (canBeMovedExternally())
+        return;
+}
+
 const QRectF MyArrowHeadBase::getExtents() {
     return QRectF(0.0, 0.0, 0.0, 0.0);
 }

--- a/src/negui_arrow_head.h
+++ b/src/negui_arrow_head.h
@@ -32,6 +32,10 @@ public:
 
     void setSelectedWithColor(const bool& selected) override;
 
+    const bool canBeMovedExternally() override;
+
+    void moveExternally(const qreal& dx, const qreal& dy) override;
+
     const QRectF getExtents() override;
 
     QWidget* getFeatureMenu() override;

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -174,10 +174,6 @@ void MyEdgeBase::enableDisplayFeatureMenuMode() {
         arrowHead()->enableDisplayFeatureMenuMode();
 }
 
-const QPointF MyEdgeBase::middlePosition() {
-    return 0.5 * (((MyNodeBase*)sourceNode())->getExtents().center() + ((MyNodeBase*)targetNode())->getExtents().center());
-}
-
 const bool MyEdgeBase::canBeMovedExternally() {
     return false;
 }
@@ -297,6 +293,10 @@ MyEdgeBase::EDGE_TYPE MyConnectedToSourceCentroidNodeEdge::edgeType() {
     return CONNECTED_TO_SOURCE_CENTROID_NODE_EDGE;
 }
 
+const QPointF MyConnectedToSourceCentroidNodeEdge::nonCentroidNodePosition() {
+    return ((MyNodeBase*)sourceNode())->getExtents().center();
+}
+
 // MyConnectedToTargetCentroidNodeEdge
 
 MyConnectedToTargetCentroidNodeEdge::MyConnectedToTargetCentroidNodeEdge(const QString& name, MyNetworkElementBase* sourceNode, MyNetworkElementBase* targetNode) : MyConnectedToCentroidNodeEdgeBase(name) {
@@ -308,6 +308,10 @@ MyConnectedToTargetCentroidNodeEdge::MyConnectedToTargetCentroidNodeEdge(const Q
 
 MyEdgeBase::EDGE_TYPE MyConnectedToTargetCentroidNodeEdge::edgeType() {
     return CONNECTED_TO_TARGET_CENTROID_NODE_EDGE;
+}
+
+const QPointF MyConnectedToTargetCentroidNodeEdge::nonCentroidNodePosition() {
+    return ((MyNodeBase*)targetNode())->getExtents().center();
 }
 
 const QPointF getEndOfTheLinePosition(MyNetworkElementBase* mainNode, MyNetworkElementBase* connectedNode) {

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -129,6 +129,7 @@ void MyEdgeBase::updatePoints() {
     QPointF targetPosition = getEndOfTheLinePosition(targetNode(), sourceNode());
     ((MyEdgeSceneGraphicsItemBase*)graphicsItem())->setLine(QLineF(sourcePosition.x(), sourcePosition.y(), targetPosition.x(), targetPosition.y()));
     graphicsItem()->setZValue(calculateZValue());
+    updateFocusedGraphicsItems();
     emit updateArrowHeadPlacement();
 }
 

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -279,6 +279,7 @@ MyConnectedToCentroidNodeEdgeBase::MyConnectedToCentroidNodeEdgeBase(const QStri
 
 void MyConnectedToCentroidNodeEdgeBase::connectGraphicsItem() {
     MyEdgeBase::connectGraphicsItem();
+    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit askForSelectNetworkElement(this); });
     connect(this, SIGNAL(askForConnectedToCentroidNodeControlPoint()), _graphicsItem, SIGNAL(askForConnectedToCentroidNodeControlPoint()));
 }
 

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -177,6 +177,15 @@ const QPointF MyEdgeBase::middlePosition() {
     return 0.5 * (((MyNodeBase*)sourceNode())->getExtents().center() + ((MyNodeBase*)targetNode())->getExtents().center());
 }
 
+const bool MyEdgeBase::canBeMovedExternally() {
+    return false;
+}
+
+void MyEdgeBase::moveExternally(const qreal& dx, const qreal& dy) {
+    if (canBeMovedExternally())
+        return;
+}
+
 const QRectF MyEdgeBase::getExtents() {
     return QRectF(0.0, 0.0, 0.0, 0.0);
 }

--- a/src/negui_edge.h
+++ b/src/negui_edge.h
@@ -43,7 +43,9 @@ public:
     void setSelectedWithColor(const bool& selected) override;
     
     MyNetworkElementBase* arrowHead();
+
     void setArrowHead();
+
     const bool isSetArrowHead() const { return _isSetArrowHead; }
     
     // determine whether the edge is visible on the scene
@@ -68,6 +70,10 @@ public:
     void enableDisplayFeatureMenuMode() override;
 
     const QPointF middlePosition();
+
+    const bool canBeMovedExternally() override;
+
+    void moveExternally(const qreal& dx, const qreal& dy) override;
     
     const QRectF getExtents() override;
     

--- a/src/negui_edge.h
+++ b/src/negui_edge.h
@@ -69,8 +69,6 @@ public:
     
     void enableDisplayFeatureMenuMode() override;
 
-    const QPointF middlePosition();
-
     const bool canBeMovedExternally() override;
 
     void moveExternally(const qreal& dx, const qreal& dy) override;
@@ -127,6 +125,8 @@ public:
 
     void connectGraphicsItem() override;
 
+    virtual const QPointF nonCentroidNodePosition() = 0;
+
 signals:
 
     const QPointF askForConnectedToCentroidNodeControlPoint();
@@ -140,6 +140,8 @@ public:
     MyConnectedToSourceCentroidNodeEdge(const QString& name, MyNetworkElementBase* sourceNode, MyNetworkElementBase* targetNode);
 
     EDGE_TYPE edgeType() override;
+
+    const QPointF nonCentroidNodePosition() override;
 };
 
 class MyConnectedToTargetCentroidNodeEdge : public MyConnectedToCentroidNodeEdgeBase {
@@ -150,6 +152,8 @@ public:
     MyConnectedToTargetCentroidNodeEdge(const QString& name, MyNetworkElementBase* sourceNode, MyNetworkElementBase* targetNode);
 
     EDGE_TYPE edgeType() override;
+
+    const QPointF nonCentroidNodePosition() override;
 };
 
 const QPointF getEndOfTheLinePosition(MyNetworkElementBase* mainNode, MyNetworkElementBase* connectedNode);

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -17,6 +17,7 @@
 #include "negui_decorate_menu_buttons.h"
 #include "negui_network_element_aligner.h"
 #include "negui_network_element_aligner_builder.h"
+#include "negui_network_element_mover.h"
 
 #include <QCoreApplication>
 #include <QFileDialog>
@@ -301,6 +302,7 @@ void MyInteractor::addNode(MyNetworkElementBase* n) {
         connect(n, SIGNAL(askForWhetherElementStyleIsCopied()), this, SLOT(isSetCopiedNodeStyle()));
         connect(n, SIGNAL(askForWhetherAnyOtherElementsAreSelected(MyNetworkElementBase*)), this, SLOT(areAnyOtherElementsSelected(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForIconsDirectoryPath()), this, SLOT(iconsDirectoryPath()));
+        connect(n, SIGNAL(positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&)), this, SLOT(moveSelectedNetworkElements(MyNetworkElementBase*, const QPointF&)));
         connect(n->graphicsItem(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
         connect(n->graphicsItem(), SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
         emit askForAddGraphicsItem(n->graphicsItem());
@@ -613,6 +615,13 @@ QList<MyNetworkElementBase*> MyInteractor::copiedNetworkElements() {
 void MyInteractor::resetCopiedNetworkElements() {
     _copiedNetworkElements.clear();
     emit pasteElementsStatusChanged(false);
+}
+
+void MyInteractor::moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance) {
+    MyNetworkElementMoverBase* nodeMover = new MyNodeMover(selectedNodes(), movedNode);
+    nodeMover->move(movedDistance.x(), movedDistance.y());
+    nodeMover->deleteLater();
+    createChangeStageCommand();
 }
 
 void MyInteractor::deleteNewEdgeBuilder() {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -621,7 +621,6 @@ void MyInteractor::moveSelectedNetworkElements(MyNetworkElementBase* movedNode, 
     MyNetworkElementMoverBase* nodeMover = new MyNodeMover(selectedNodes(), movedNode);
     nodeMover->move(movedDistance.x(), movedDistance.y());
     nodeMover->deleteLater();
-    createChangeStageCommand();
 }
 
 void MyInteractor::deleteNewEdgeBuilder() {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -724,12 +724,17 @@ void MyInteractor::selectEdges(const bool& selected, const QString& category) {
 
 void MyInteractor::selectElement(MyNetworkElementBase* element) {
     if (getSceneMode() == NORMAL_MODE) {
-        if (!askForWhetherShiftModifierIsPressed())
-            selectElements(false);
-        if (!element->isSelected())
+        if (askForWhetherShiftModifierIsPressed()) {
+            if (!element->isSelected())
+                element->setSelected(true);
+            else
+                element->setSelected(false);
+        }
+        else {
+            if (!(element->isSelected() && areAnyOtherElementsSelected(element)))
+                selectElements(false);
             element->setSelected(true);
-        else
-            element->setSelected(false);
+        }
         emit elementsCuttableStatusChanged(areSelectedElementsCuttable());
         emit elementsCopyableStatusChanged(areSelectedElementsCopyable());
     }

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -112,7 +112,7 @@ signals:
     void elementsCuttableStatusChanged(const bool&);
     void elementsCopyableStatusChanged(const bool&);
     void pasteElementsStatusChanged(const bool&);
-    
+
     void enterKeyIsPressed();
     
 public slots:
@@ -156,6 +156,7 @@ public slots:
     const bool areAnyElementsSelected();
     const QString iconsDirectoryPath();
     QJsonObject getNetworkElementsInfo();
+    void moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance);
     
     // modes
     void enableNormalMode() override;

--- a/src/negui_network_element_aligner.cpp
+++ b/src/negui_network_element_aligner.cpp
@@ -16,7 +16,6 @@ MyNodeAlignerBase::MyNodeAlignerBase(QList<MyNetworkElementBase*> networkElement
 void MyNodeAlignerBase::align() {
     extractExtents();
     adjustNodePositions();
-    updateNodeFocusedGraphicsItems();
 }
 
 void MyNodeAlignerBase::extractExtents() {
@@ -38,11 +37,6 @@ void MyNodeAlignerBase::extractExtents() {
     }
 }
 
-void MyNodeAlignerBase::updateNodeFocusedGraphicsItems() {
-    for (MyNetworkElementBase* node : _networkElements)
-        ((MyNodeBase*)node)->graphicsItem()->updateFocusedGraphicsItems();
-}
-
 // MyNodeTopAligner
 
 MyNodeTopAligner::MyNodeTopAligner(QList<MyNetworkElementBase*> networkElements) : MyNodeAlignerBase(networkElements) {
@@ -51,7 +45,7 @@ MyNodeTopAligner::MyNodeTopAligner(QList<MyNetworkElementBase*> networkElements)
 
 void MyNodeTopAligner::adjustNodePositions() {
     for (MyNetworkElementBase* node : _networkElements)
-        ((MyNodeBase*)node)->graphicsItem()->moveBy(0, _minY - ((MyNodeBase*)node)->position().y());
+        ((MyNodeBase*)node)->moveExternally(0, _minY - ((MyNodeBase*)node)->position().y());
 }
 
 // MyNodeMiddleAligner
@@ -62,7 +56,7 @@ MyNodeMiddleAligner::MyNodeMiddleAligner(QList<MyNetworkElementBase*> networkEle
 
 void MyNodeMiddleAligner::adjustNodePositions() {
     for (MyNetworkElementBase* node : _networkElements)
-        ((MyNodeBase*)node)->graphicsItem()->moveBy(0, 0.5 * (_minY + _maxY) - ((MyNodeBase*)node)->position().y());
+        ((MyNodeBase*)node)->moveExternally(0, 0.5 * (_minY + _maxY) - ((MyNodeBase*)node)->position().y());
 }
 
 // MyNodeBottomAligner
@@ -73,7 +67,7 @@ MyNodeBottomAligner::MyNodeBottomAligner(QList<MyNetworkElementBase*> networkEle
 
 void MyNodeBottomAligner::adjustNodePositions() {
     for (MyNetworkElementBase* node : _networkElements)
-        ((MyNodeBase*)node)->graphicsItem()->moveBy(0, _maxY - ((MyNodeBase*)node)->position().y());
+        ((MyNodeBase*)node)->moveExternally(0, _maxY - ((MyNodeBase*)node)->position().y());
 }
 
 // MyNodeLeftAligner
@@ -84,7 +78,7 @@ MyNodeLeftAligner::MyNodeLeftAligner(QList<MyNetworkElementBase*> networkElement
 
 void MyNodeLeftAligner::adjustNodePositions() {
     for (MyNetworkElementBase* node : _networkElements)
-        ((MyNodeBase*)node)->graphicsItem()->moveBy(_minX - ((MyNodeBase*)node)->position().x(), 0);
+        ((MyNodeBase*)node)->moveExternally(_minX - ((MyNodeBase*)node)->position().x(), 0);
 }
 
 // MyNodeCenterAligner
@@ -95,7 +89,7 @@ MyNodeCenterAligner::MyNodeCenterAligner(QList<MyNetworkElementBase*> networkEle
 
 void MyNodeCenterAligner::adjustNodePositions() {
     for (MyNetworkElementBase* node : _networkElements)
-        ((MyNodeBase*)node)->graphicsItem()->moveBy(0.5 * (_minX + _maxX) - ((MyNodeBase*)node)->position().x(), 0);
+        ((MyNodeBase*)node)->moveExternally(0.5 * (_minX + _maxX) - ((MyNodeBase*)node)->position().x(), 0);
 }
 
 // MyNodeRightAligner
@@ -106,7 +100,7 @@ MyNodeRightAligner::MyNodeRightAligner(QList<MyNetworkElementBase*> networkEleme
 
 void MyNodeRightAligner::adjustNodePositions() {
     for (MyNetworkElementBase* node : _networkElements)
-        ((MyNodeBase*)node)->graphicsItem()->moveBy(_maxX - ((MyNodeBase*)node)->position().x(), 0);
+        ((MyNodeBase*)node)->moveExternally(_maxX - ((MyNodeBase*)node)->position().x(), 0);
 }
 
 // MyNodeDistributeAlignerBase
@@ -135,7 +129,7 @@ void MyNodeHorizontallyDistributeAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     qreal distributionDistance = (_maxX - _minX) / (classicNodes.size() - 1);
     for (unsigned  int i = 0; i < classicNodes.size(); i++)
-        ((MyNodeBase*)classicNodes.at(i))->graphicsItem()->moveBy(_minX - ((MyNodeBase*)classicNodes.at(i))->position().x() + i * distributionDistance, 0);
+        ((MyNodeBase*)classicNodes.at(i))->moveExternally(_minX - ((MyNodeBase*)classicNodes.at(i))->position().x() + i * distributionDistance, 0);
 }
 
 // MyNodeVerticallyDistributeAligner
@@ -148,5 +142,5 @@ void MyNodeVerticallyDistributeAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     qreal distributionDistance = (_maxY - _minY) / (classicNodes.size() - 1);
     for (unsigned  int i = 0; i < classicNodes.size(); i++)
-        ((MyNodeBase*)classicNodes.at(i))->graphicsItem()->moveBy(0, _minY - ((MyNodeBase*)classicNodes.at(i))->position().y() + i * distributionDistance);
+        ((MyNodeBase*)classicNodes.at(i))->moveExternally(0, _minY - ((MyNodeBase*)classicNodes.at(i))->position().y() + i * distributionDistance);
 }

--- a/src/negui_network_element_aligner.h
+++ b/src/negui_network_element_aligner.h
@@ -32,7 +32,13 @@ public:
 
     void extractExtents();
 
+    QList<MyNetworkElementBase*> getClassicNodes();
+
+    QList<MyNetworkElementBase*> getCentroidNodes();
+
     virtual void adjustNodePositions() = 0;
+
+    void adjustCentroidNodePositions();
 };
 
 class MyNodeTopAligner : public MyNodeAlignerBase {
@@ -103,8 +109,6 @@ class MyNodeDistributeAlignerBase : public MyNodeAlignerBase {
 public:
 
     MyNodeDistributeAlignerBase(QList<MyNetworkElementBase*> networkElements);
-
-    QList<MyNetworkElementBase*> getClassicNodes();
 };
 
 class MyNodeHorizontallyDistributeAligner : public MyNodeDistributeAlignerBase {

--- a/src/negui_network_element_aligner.h
+++ b/src/negui_network_element_aligner.h
@@ -33,8 +33,6 @@ public:
     void extractExtents();
 
     virtual void adjustNodePositions() = 0;
-
-    void updateNodeFocusedGraphicsItems();
 };
 
 class MyNodeTopAligner : public MyNodeAlignerBase {

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -32,7 +32,6 @@ void MyNetworkElementBase::updateFocusedGraphicsItems() {
 }
 
 void MyNetworkElementBase::connectGraphicsItem() {
-    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit askForSelectNetworkElement(this); });
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForDeleteNetworkElement, this, [this] () { emit askForDeleteNetworkElement(this); });
     connect(_graphicsItem, SIGNAL(askForWhetherNetworkElementIsSelected()), this, SLOT(isSelected()));
     connect(_graphicsItem, SIGNAL(askForCreateFeatureMenu()), this, SLOT(createFeatureMenu()));

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -64,6 +64,10 @@ public:
     void enableDisplayFeatureMenuMode() override;
     
     virtual const QRectF getExtents() = 0;
+
+    virtual const bool canBeMovedExternally() = 0;
+
+    virtual void moveExternally(const qreal& dx, const qreal& dy) = 0;
     
     virtual QWidget* getFeatureMenu();
     
@@ -71,7 +75,7 @@ public:
 
     QWidget* createAndConnectFeatureMenuObject();
 
-    signals:
+signals:
     
     void askForSelectNetworkElement(MyNetworkElementBase*);
     

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -132,8 +132,10 @@ QList<QGraphicsItem*> MyNetworkElementGraphicsItemBase::createFocusedGraphicsIte
 }
 
 void MyNetworkElementGraphicsItemBase::updateFocusedGraphicsItems() {
+    bool isSelected = _focusedGraphicsItems.size() ? true : false;
     clearFocusedGraphicsItems();
-    addFocusedGraphicsItems();
+    if (isSelected)
+        addFocusedGraphicsItems();
 }
 
 void MyNetworkElementGraphicsItemBase::addFocusedGraphicsItems() {
@@ -233,7 +235,6 @@ void MyNetworkElementGraphicsItemBase::mousePressEvent(QGraphicsSceneMouseEvent 
 }
 
 void MyNetworkElementGraphicsItemBase::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
-    QGraphicsItem::mouseReleaseEvent(event);
     if (event->button() == Qt::LeftButton) {
         _isChosen = false;
         event->accept();
@@ -243,6 +244,7 @@ void MyNetworkElementGraphicsItemBase::mouseReleaseEvent(QGraphicsSceneMouseEven
         displayContextMenu(event->screenPos());
         event->accept();
     }
+    QGraphicsItem::mouseReleaseEvent(event);
 }
 
 void MyNetworkElementGraphicsItemBase::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -226,12 +226,12 @@ void MyNetworkElementGraphicsItemBase::setZValue(qreal z) {
 }
 
 void MyNetworkElementGraphicsItemBase::mousePressEvent(QGraphicsSceneMouseEvent *event) {
+    QGraphicsItem::mousePressEvent(event);
     if (event->button() == Qt::LeftButton) {
         _isChosen = true;
         emit mouseLeftButtonIsPressed();
         event->accept();
     }
-    QGraphicsItem::mousePressEvent(event);
 }
 
 void MyNetworkElementGraphicsItemBase::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {

--- a/src/negui_network_element_mover.cpp
+++ b/src/negui_network_element_mover.cpp
@@ -15,5 +15,8 @@ MyNodeMover::MyNodeMover(QList<MyNetworkElementBase*> networkElements, MyNetwork
 }
 
 void MyNodeMover::move(const qreal& dx, const qreal& dy) {
-
+    for (MyNetworkElementBase* networkElement : _networkElements) {
+        if (networkElement != _movedNetworkElement)
+            ((MyNodeBase*)networkElement)->moveExternally(dx, dy);
+    }
 }

--- a/src/negui_network_element_mover.cpp
+++ b/src/negui_network_element_mover.cpp
@@ -1,0 +1,19 @@
+#include "negui_network_element_mover.h"
+#include "negui_node.h"
+
+// MyNetworkElementMoverBase
+
+MyNetworkElementMoverBase::MyNetworkElementMoverBase(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement) {
+    _networkElements = networkElements;
+    _movedNetworkElement = movedNetworkElement;
+}
+
+// MyNodeMover
+
+MyNodeMover::MyNodeMover(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement) : MyNetworkElementMoverBase(networkElements, movedNetworkElement) {
+
+}
+
+void MyNodeMover::move(const qreal& dx, const qreal& dy) {
+
+}

--- a/src/negui_network_element_mover.h
+++ b/src/negui_network_element_mover.h
@@ -1,0 +1,32 @@
+#ifndef __NEGUI_NETWORK_ELEMENT_MOVER_H
+#define __NEGUI_NETWORK_ELEMENT_MOVER_H
+
+#include "negui_network_element_base.h"
+
+class MyNetworkElementMoverBase : public QObject {
+    Q_OBJECT
+
+public:
+
+    MyNetworkElementMoverBase(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement);
+
+    virtual void move(const qreal& dx, const qreal& dy) = 0;
+
+protected:
+
+    QList<MyNetworkElementBase*> _networkElements;
+    MyNetworkElementBase* _movedNetworkElement;
+};
+
+class MyNodeMover : public MyNetworkElementMoverBase {
+    Q_OBJECT
+
+public:
+
+    MyNodeMover(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement);
+
+    void move(const qreal& dx, const qreal& dy) override;
+
+};
+
+#endif

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -25,12 +25,11 @@ MyNodeBase::ELEMENT_TYPE MyNodeBase::type() {
 
 void MyNodeBase::connectGraphicsItem() {
     MyNetworkElementBase::connectGraphicsItem();
-    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () {
-        emit askForSelectNetworkElement(this); });
+    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit askForSelectNetworkElement(this); });
     connect(_graphicsItem, SIGNAL(askForDeparent()), this,  SLOT(deparent()));
     connect(_graphicsItem, SIGNAL(askForReparent()), this, SLOT(reparent()));
     connect(_graphicsItem, SIGNAL(askForResetPosition()), this, SLOT(resetPosition()));
-    //connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedEdges()));
+    connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedEdges()));
     connect((MyNodeSceneGraphicsItemBase*)_graphicsItem, &MyNodeSceneGraphicsItemBase::positionChangedByMouseMoveEvent, this, [this] (const QPointF& movedDistance) { positionChangedByMouseMoveEvent(this, movedDistance); });
 }
 
@@ -502,6 +501,7 @@ void MyCentroidNode::adjustNodePositionToNeighborNodes() {
     if (isNodePositionConnectedToNeighborNodes() && edges().size()) {
         QPointF updatedPosition = getNodeUpdatedPositionUsingConnectedEdges();
         ((MyCentroidNodeSceneGraphicsItem*)graphicsItem())->moveBy((updatedPosition - _position).x(), (updatedPosition - _position).y());
+        updateFocusedGraphicsItems();
         adjustConnectedBezierCurves();
     }
 }

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -26,12 +26,11 @@ MyNodeBase::ELEMENT_TYPE MyNodeBase::type() {
 void MyNodeBase::connectGraphicsItem() {
     MyNetworkElementBase::connectGraphicsItem();
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () {
-        if (!isSelected() || !askForWhetherAnyOtherElementsAreSelected(this))
-            emit askForSelectNetworkElement(this); });
+        emit askForSelectNetworkElement(this); });
     connect(_graphicsItem, SIGNAL(askForDeparent()), this,  SLOT(deparent()));
     connect(_graphicsItem, SIGNAL(askForReparent()), this, SLOT(reparent()));
     connect(_graphicsItem, SIGNAL(askForResetPosition()), this, SLOT(resetPosition()));
-    connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedEdges()));
+    //connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedEdges()));
     connect((MyNodeSceneGraphicsItemBase*)_graphicsItem, &MyNodeSceneGraphicsItemBase::positionChangedByMouseMoveEvent, this, [this] (const QPointF& movedDistance) { positionChangedByMouseMoveEvent(this, movedDistance); });
 }
 

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -141,6 +141,12 @@ const QPointF MyNodeBase::position() const {
     return _position;
 }
 
+void MyNodeBase::moveExternally(const qreal& dx, const qreal& dy) {
+    if (canBeMovedExternally())
+        graphicsItem()->moveBy(dx, dy);
+    updateFocusedGraphicsItems();
+}
+
 const QRectF MyNodeBase::getExtents() {
     return ((MyNodeSceneGraphicsItemBase*)graphicsItem())->getExtents();
 }
@@ -282,6 +288,17 @@ void MyClassicNodeBase::setPosition(const QPointF& position) {
         lockChildNodes(false);
 
     MyNodeBase::setPosition(position);
+}
+
+const bool MyClassicNodeBase::canBeMovedExternally() {
+    if (childNodes().size()) {
+        for (MyNetworkElementBase* childNode : qAsConst(childNodes())) {
+            if (childNode->isSelected())
+                return false;
+        }
+    }
+
+    return true;
 }
 
 const QRectF MyClassicNodeBase::getExtents() {
@@ -518,6 +535,10 @@ void MyCentroidNode::setSelected(const bool& selected) {
         for (MyNetworkElementBase *edge : qAsConst(edges()))
             edge->setSelected(selected);
     }
+}
+
+const bool MyCentroidNode::canBeMovedExternally() {
+    return true;
 }
 
 QWidget* MyCentroidNode::getFeatureMenu() {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -521,8 +521,8 @@ const bool MyCentroidNode::connectedBezierCurvesNeedsToBeAdjusted() {
 const QPointF MyCentroidNode::getNodeUpdatedPositionUsingConnectedEdges() {
     QPointF position = QPointF(0.0, 0.0);
     for (MyNetworkElementBase *edge : qAsConst(edges()))
-        position += ((MyEdgeBase*)edge)->middlePosition();
-    return position /= edges().size();
+        position += ((MyConnectedToCentroidNodeEdgeBase*)edge)->nonCentroidNodePosition();
+    return position / edges().size();
 }
 
 const bool MyCentroidNode::isNodePositionConnectedToNeighborNodes() {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -25,6 +25,9 @@ MyNodeBase::ELEMENT_TYPE MyNodeBase::type() {
 
 void MyNodeBase::connectGraphicsItem() {
     MyNetworkElementBase::connectGraphicsItem();
+    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () {
+        if (!isSelected() || !askForWhetherAnyOtherElementsAreSelected(this))
+            emit askForSelectNetworkElement(this); });
     connect(_graphicsItem, SIGNAL(askForDeparent()), this,  SLOT(deparent()));
     connect(_graphicsItem, SIGNAL(askForReparent()), this, SLOT(reparent()));
     connect(_graphicsItem, SIGNAL(askForResetPosition()), this, SLOT(resetPosition()));
@@ -139,12 +142,6 @@ void MyNodeBase::resetPosition() {
 
 const QPointF MyNodeBase::position() const {
     return _position;
-}
-
-void MyNodeBase::moveExternally(const qreal& dx, const qreal& dy) {
-    if (canBeMovedExternally())
-        graphicsItem()->moveBy(dx, dy);
-    updateFocusedGraphicsItems();
 }
 
 const QRectF MyNodeBase::getExtents() {
@@ -288,6 +285,14 @@ void MyClassicNodeBase::setPosition(const QPointF& position) {
         lockChildNodes(false);
 
     MyNodeBase::setPosition(position);
+}
+
+void MyClassicNodeBase::moveExternally(const qreal& dx, const qreal& dy) {
+    if (canBeMovedExternally()) {
+        graphicsItem()->moveBy(dx, dy);
+        adjustConnectedEdges();
+    }
+    updateFocusedGraphicsItems();
 }
 
 const bool MyClassicNodeBase::canBeMovedExternally() {
@@ -537,8 +542,13 @@ void MyCentroidNode::setSelected(const bool& selected) {
     }
 }
 
+void MyCentroidNode::moveExternally(const qreal& dx, const qreal& dy) {
+    if (canBeMovedExternally())
+        return;
+}
+
 const bool MyCentroidNode::canBeMovedExternally() {
-    return true;
+    return false;
 }
 
 QWidget* MyCentroidNode::getFeatureMenu() {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -28,7 +28,8 @@ void MyNodeBase::connectGraphicsItem() {
     connect(_graphicsItem, SIGNAL(askForDeparent()), this,  SLOT(deparent()));
     connect(_graphicsItem, SIGNAL(askForReparent()), this, SLOT(reparent()));
     connect(_graphicsItem, SIGNAL(askForResetPosition()), this, SLOT(resetPosition()));
-    connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent()), this, SLOT(adjustConnectedEdges()));
+    connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedEdges()));
+    connect((MyNodeSceneGraphicsItemBase*)_graphicsItem, &MyNodeSceneGraphicsItemBase::positionChangedByMouseMoveEvent, this, [this] (const QPointF& movedDistance) { positionChangedByMouseMoveEvent(this, movedDistance); });
 }
 
 void MyNodeBase::addEdge(MyNetworkElementBase* e) {
@@ -444,7 +445,7 @@ void MyCentroidNode::connectGraphicsItem() {
     MyNodeBase::connectGraphicsItem();
     connect(_graphicsItem, SIGNAL(askForGetBezierAdjustLine()), this, SLOT(createBezierAdjustLine()));
     connect(_graphicsItem, SIGNAL(bezierAdjustLineIsUpdated(const QLineF&)), this, SIGNAL(bezierAdjustLineIsUpdated(const QLineF&)));
-    connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent()), this, SLOT(adjustConnectedBezierCurves()));
+    connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedBezierCurves()));
     connect(_graphicsItem, SIGNAL(askForConnectNodePositionToNeighborNodes(const bool&)), this, SLOT(connectNodePositionToNeighborNodes(const bool&)));
     connect(_graphicsItem, SIGNAL(askForWhetherNodePositionIsConnectedToNeighborNodes()), this, SLOT(isNodePositionConnectedToNeighborNodes()));
 }

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -63,8 +63,6 @@ public:
     // return true if the child nodes of the node are locked
     const bool isParentNodeLocked() const { return _isParentNodeLocked; }
 
-    void moveExternally(const qreal& dx, const qreal& dy) override;
-
     const QRectF getExtents() override;
 
     const qreal endEdgePadding();
@@ -139,6 +137,8 @@ public:
 
     // return true if the child nodes of the node are locked
     const bool areChildNodesLocked() const { return _areChildNodesLocked; }
+
+    void moveExternally(const qreal& dx, const qreal& dy) override;
 
     const bool canBeMovedExternally() override;
 
@@ -228,6 +228,8 @@ public:
     const QPointF getNodeUpdatedPositionUsingConnectedEdges();
 
     const bool connectedBezierCurvesNeedsToBeAdjusted();
+
+    void moveExternally(const qreal& dx, const qreal& dy) override;
 
     const bool canBeMovedExternally() override;
 

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -63,6 +63,8 @@ public:
     // return true if the child nodes of the node are locked
     const bool isParentNodeLocked() const { return _isParentNodeLocked; }
 
+    void moveExternally(const qreal& dx, const qreal& dy) override;
+
     const QRectF getExtents() override;
 
     const qreal endEdgePadding();
@@ -137,6 +139,8 @@ public:
 
     // return true if the child nodes of the node are locked
     const bool areChildNodesLocked() const { return _areChildNodesLocked; }
+
+    const bool canBeMovedExternally() override;
 
     // get node extents based on its children extents
     const QRectF getExtents() override;
@@ -224,6 +228,8 @@ public:
     const QPointF getNodeUpdatedPositionUsingConnectedEdges();
 
     const bool connectedBezierCurvesNeedsToBeAdjusted();
+
+    const bool canBeMovedExternally() override;
 
     QWidget* getFeatureMenu() override;
 

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -82,6 +82,8 @@ public:
 signals:
     
     MyNetworkElementBase* askForParentNodeAtPosition(MyNetworkElementBase* currentNode, const QPointF& position);
+
+    void positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&);
     
 public slots:
     

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -239,9 +239,11 @@ signals:
 
     void bezierAdjustLineIsUpdated(const QLineF&);
 
-private slots:
+public slots:
 
     void adjustNodePositionToNeighborNodes();
+
+private slots:
 
     void adjustConnectedBezierCurves();
 

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -35,7 +35,7 @@ MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position
     setFlag(QGraphicsItem::ItemIsFocusable, true);
     
     _reparent = false;
-    connect(this, SIGNAL(positionChangedByMouseMoveEvent()), this, SLOT(updateFocusedGraphicsItems()));
+    connect(this, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(updateFocusedGraphicsItems()));
     
     setZValue(2);
 }
@@ -98,9 +98,14 @@ QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, cons
     return QGraphicsItem::itemChange(change, value);
 }
 
+void MyNodeSceneGraphicsItemBase::mousePressEvent(QGraphicsSceneMouseEvent *event) {
+    MyNetworkElementGraphicsItemBase::mousePressEvent(event);
+    _mousePressedPosition = event->pos();
+}
+
 void MyNodeSceneGraphicsItemBase::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     MyNetworkElementGraphicsItemBase::mouseMoveEvent(event);
-    emit positionChangedByMouseMoveEvent();
+    emit positionChangedByMouseMoveEvent(event->pos() - _mousePressedPosition);
 }
 
 void MyNodeSceneGraphicsItemBase::keyPressEvent(QKeyEvent *event) {

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -98,14 +98,9 @@ QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, cons
     return QGraphicsItem::itemChange(change, value);
 }
 
-void MyNodeSceneGraphicsItemBase::mousePressEvent(QGraphicsSceneMouseEvent *event) {
-    MyNetworkElementGraphicsItemBase::mousePressEvent(event);
-    _mousePressedPosition = event->pos();
-}
-
 void MyNodeSceneGraphicsItemBase::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     MyNetworkElementGraphicsItemBase::mouseMoveEvent(event);
-    emit positionChangedByMouseMoveEvent(event->pos() - _mousePressedPosition);
+    emit positionChangedByMouseMoveEvent(event->scenePos() - event->lastScenePos());
 }
 
 void MyNodeSceneGraphicsItemBase::keyPressEvent(QKeyEvent *event) {

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -60,8 +60,6 @@ protected:
 
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
-    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
-
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     
     void keyPressEvent(QKeyEvent *event) override;
@@ -69,7 +67,6 @@ protected:
     void keyReleaseEvent(QKeyEvent *event) override;
     
     bool _reparent;
-    QPointF _mousePressedPosition;
 };
 
 class MyClassicNodeSceneGraphicsItemBase : public MyNodeSceneGraphicsItemBase {

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -54,11 +54,13 @@ signals:
     
     void askForResetPosition();
 
-    void positionChangedByMouseMoveEvent();
+    void positionChangedByMouseMoveEvent(const QPointF&);
     
 protected:
 
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     
@@ -67,6 +69,7 @@ protected:
     void keyReleaseEvent(QKeyEvent *event) override;
     
     bool _reparent;
+    QPointF _mousePressedPosition;
 };
 
 class MyClassicNodeSceneGraphicsItemBase : public MyNodeSceneGraphicsItemBase {


### PR DESCRIPTION
- an element mover class is created and used in the interactor

- the signal position changed by mouse move event is added to the node class emiited when a node positon changed by the user. This signal is connected to the move selected nodes function in the interactor

- move externally functions are added to the node class and its derivatives, and is used to move a node from outside the class in accordance with the node features

- select netwrok element function in the interactor is updated so that it is possbile to click one node in the group of selected nodes and move them

- update focused graphics item is updated such that only if focused graphics item already existed, they are added again. Also,  the focused graphics items of a centroid node and edge are also updated when they are moved

- the centroid node postions are now adjusted after their connecting nodes are aligned

This PR fixes #39 and also have some bug fixes related to #11
