### PR TITLE
Fix the problem with displaying the context (right-click) menu when a group of elements are selected

### DIFF
--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -309,6 +309,7 @@ void MyInteractor::addNode(MyNetworkElementBase* n) {
         connect(n, SIGNAL(askForWhetherAnyOtherElementsAreSelected(MyNetworkElementBase*)), this, SLOT(areAnyOtherElementsSelected(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForIconsDirectoryPath()), this, SLOT(iconsDirectoryPath()));
         connect(n, SIGNAL(positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&)), this, SLOT(moveSelectedNetworkElements(MyNetworkElementBase*, const QPointF&)));
+        connect(n, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
         connect(n->graphicsItem(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
         connect(n->graphicsItem(), SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
         emit askForAddGraphicsItem(n->graphicsItem());

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -115,6 +115,7 @@ signals:
     void elementsCuttableStatusChanged(const bool&);
     void elementsCopyableStatusChanged(const bool&);
     void pasteElementsStatusChanged(const bool&);
+    void askForDisplaySceneContextMenu(const QPointF&);
 
     void enterKeyIsPressed();
     

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -164,6 +164,7 @@ void MyNetworkEditorWidget::setInteractions() {
     connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForPasteCopiedNetworkElements(const QPointF &)), (MyInteractor*)interactor(), SLOT(pasteCopiedNetworkElements(const QPointF &)));
     connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForDeleteSelectedNetworkElements()), (MyInteractor*)interactor(), SLOT(deleteSelectedNetworkElements()));
     connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForAlignSelectedNetworkElements(const QString&)), (MyInteractor*)interactor(), SLOT(alignSelectedNetworkElements(const QString&)));
+    connect((MyInteractor*)interactor(), SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), ((MyGraphicsView*)view())->scene(), SLOT(displayContextMenu(const QPointF&)));
 
     // status bar
     connect(view(), SIGNAL(mouseLeft()), statusBar(), SLOT(resetMessage()));

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -42,6 +42,7 @@ void MyNetworkElementBase::connectGraphicsItem() {
     connect(_graphicsItem, SIGNAL(askForWhetherAnyOtherElementsAreSelected()), this, SLOT(areAnyOtherElementsSelected()));
     connect(_graphicsItem, SIGNAL(askForWhetherElementStyleIsCopied()), this, SIGNAL(askForWhetherElementStyleIsCopied()));
     connect(_graphicsItem, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
+    connect(_graphicsItem, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
 }
 
 MyNetworkElementStyleBase* MyNetworkElementBase::style() {

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -103,6 +103,8 @@ signals:
 
     const bool askForCheckWhetherNetworkElementNameIsAlreadyUsed(const QString&);
 
+    void askForDisplaySceneContextMenu(const QPointF&);
+
 public slots:
 
     virtual void setSelected(const bool& selected);

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -257,9 +257,11 @@ void MyNetworkElementGraphicsItemBase::mouseDoubleClickEvent(QGraphicsSceneMouse
 
 void MyNetworkElementGraphicsItemBase::displayContextMenu(const QPoint& position) {
     if (getSceneMode() == NORMAL_MODE) {
-        if (!(askForWhetherNetworkElementIsSelected() && askForWhetherAnyOtherElementsAreSelected())) {
+        if (!askForWhetherAnyOtherElementsAreSelected() || !askForWhetherNetworkElementIsSelected()) {
             QMenu* contextMenu = createContextMenu();
             contextMenu->exec(position);
         }
+        else
+            askForDisplaySceneContextMenu(position);
     }
 }

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -82,6 +82,7 @@ signals:
     const bool askForWhetherElementStyleIsCopied();
     const bool askForWhetherAnyOtherElementsAreSelected();
     QString askForDisplayName();
+    void askForDisplaySceneContextMenu(const QPointF&);
 
 public slots:
 


### PR DESCRIPTION
Once an elemen is right-clicked:

- if a group of elements, including the same element, are already selected, the context menu for the element is not displayed. Instead, the context menu for the graphics scene is displayed.

This PR resolves #81 issue.