### PR TITLE
Working directory firstly is set to the "Docuemtns" direcory and is now remembered when app is closed and relaunched

### DIFF
--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -1086,6 +1086,8 @@ void MyInteractor::loadPlugins() {
 void MyInteractor::setFileManager() {
     _fileManager = new MyFileManager(getPluginsOfType(plugins(), "importtool"), getPluginsOfType(plugins(), "dataexporttool"));
     connect(_fileManager, SIGNAL(currentFileNameIsUpdated(const QString&)), this, SIGNAL(currentFileNameIsUpdated(const QString&)));
+    connect(this, &MyInteractor::askForWorkingDirectoryPath, this, [this] () { return ((MyFileManager*)fileManager())->workingDirectory(); });
+    connect(this, &MyInteractor::askForSettingWorkingDirectoryPath, this, [this] (const QString& workingDirectoryPath) { ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(workingDirectoryPath).absolutePath()); });
 }
 
 QList<QAbstractButton*> MyInteractor::getToolBarMenuButtons() {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -991,7 +991,7 @@ void MyInteractor::readFromFile(MyPluginItemBase* importTool) {
         ((MyFileManager*)fileManager())->setCurrentExportToolCompatibleWithImportTool(importTool);
         ((MyFileManager*)fileManager())->setCurrentFileName(fileName);
         ((MyFileManager*)fileManager())->setLastSavedFileName(fileName);
-        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath());
+        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath() + "/");
     }
 }
 
@@ -1017,7 +1017,7 @@ void MyInteractor::writeDataToFile(MyPluginItemBase* exportTool, const QString& 
         ((MyFileManager*)fileManager())->setCurrentExportTool(exportTool);
         ((MyFileManager*)fileManager())->setCurrentFileName(fileName);
         ((MyFileManager*)fileManager())->setLastSavedFileName(fileName);
-        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath());
+        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath() + "/");
     }
     ((MyDataExportTool*)exportTool)->showMessages();
 }
@@ -1087,7 +1087,7 @@ void MyInteractor::setFileManager() {
     _fileManager = new MyFileManager(getPluginsOfType(plugins(), "importtool"), getPluginsOfType(plugins(), "dataexporttool"));
     connect(_fileManager, SIGNAL(currentFileNameIsUpdated(const QString&)), this, SIGNAL(currentFileNameIsUpdated(const QString&)));
     connect(this, &MyInteractor::askForWorkingDirectoryPath, this, [this] () { return ((MyFileManager*)fileManager())->workingDirectory(); });
-    connect(this, &MyInteractor::askForSettingWorkingDirectoryPath, this, [this] (const QString& workingDirectoryPath) { ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(workingDirectoryPath).absolutePath()); });
+    connect(this, &MyInteractor::askForSettingWorkingDirectoryPath, this, [this] (const QString& workingDirectoryPath) { ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(workingDirectoryPath).absolutePath() + "/"); });
 }
 
 QList<QAbstractButton*> MyInteractor::getToolBarMenuButtons() {

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -116,6 +116,8 @@ signals:
     void elementsCopyableStatusChanged(const bool&);
     void pasteElementsStatusChanged(const bool&);
     void askForDisplaySceneContextMenu(const QPointF&);
+    QString askForWorkingDirectoryPath();
+    void askForSettingWorkingDirectoryPath(const QString&);
 
     void enterKeyIsPressed();
     

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -259,7 +259,7 @@ void MyNetworkEditorWidget::readSettings() {
     // working directory
     const auto workingDirectory = settings.value("working directory", QByteArray()).toByteArray();
     if (workingDirectory.isEmpty())
-        ((MyInteractor*)interactor())->askForSettingWorkingDirectoryPath(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+        ((MyInteractor*)interactor())->askForSettingWorkingDirectoryPath(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/Documents");
     else
         ((MyInteractor*)interactor())->askForSettingWorkingDirectoryPath(workingDirectory);
 

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -259,7 +259,7 @@ void MyNetworkEditorWidget::readSettings() {
     // working directory
     const auto workingDirectory = settings.value("working directory", QByteArray()).toByteArray();
     if (workingDirectory.isEmpty())
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+        ((MyInteractor*)interactor())->askForSettingWorkingDirectoryPath(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
     else
         ((MyInteractor*)interactor())->askForSettingWorkingDirectoryPath(workingDirectory);
 

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -9,6 +9,7 @@
 
 #include <QGridLayout>
 #include <QSettings>
+#include <QStandardPaths>
 
 // MyNetworkEditorWidget
 
@@ -16,7 +17,6 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     setObjectName("main_widget");
     setStyleSheet("QFrame {background-color : white}");
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    readSettings();
 
     setWidgets();
     setInteractions();
@@ -31,6 +31,7 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     setLayout(layout);
     arrangeWidgetLayers();
 
+    readSettings();
     setReadyToLaunch();
 }
 
@@ -247,21 +248,37 @@ void MyNetworkEditorWidget::setReadyToLaunch() {
 void MyNetworkEditorWidget::readSettings() {
     QSettings settings("MyCompany", "NetworkEditorGUI");
     settings.beginGroup("NetworkEditorWidget");
-    const auto geometry1 = settings.value("geometry", QByteArray()).toByteArray();
-    if (geometry1.isEmpty())
+
+    // window size
+    const auto geometry = settings.value("geometry", QByteArray()).toByteArray();
+    if (geometry.isEmpty())
         setGeometry(200, 200, 1050, 700);
     else
-        restoreGeometry(geometry1);
+        restoreGeometry(geometry);
+
+    // working directory
+    const auto workingDirectory = settings.value("working directory", QByteArray()).toByteArray();
+    if (workingDirectory.isEmpty())
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    else
+        ((MyInteractor*)interactor())->askForSettingWorkingDirectoryPath(workingDirectory);
+
     settings.endGroup();
 }
 
 void MyNetworkEditorWidget::writeSettings() {
     QSettings settings("MyCompany", "NetworkEditorGUI");
     settings.beginGroup("NetworkEditorWidget");
+
+    // window size
     if (dynamic_cast<QWidget*>(parent()))
         settings.setValue("geometry", ((QWidget*)parent())->saveGeometry());
     else
         settings.setValue("geometry", saveGeometry());
+
+    // working directory
+    settings.setValue("working directory", ((MyInteractor*)interactor())->askForWorkingDirectoryPath());
+
     settings.endGroup();
 }
 


### PR DESCRIPTION
- working direcotry is initially set to the "Documents" direcory of the platfrom in-use

- last working direcotry is saved when the app closes

- last working direcory is loaded and set when the app relaunches

This PR fixes #85 issue