### PR TITLE
Node text vertical alignment is fixed

### DIFF
--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -1086,6 +1086,8 @@ void MyInteractor::loadPlugins() {
 void MyInteractor::setFileManager() {
     _fileManager = new MyFileManager(getPluginsOfType(plugins(), "importtool"), getPluginsOfType(plugins(), "dataexporttool"));
     connect(_fileManager, SIGNAL(currentFileNameIsUpdated(const QString&)), this, SIGNAL(currentFileNameIsUpdated(const QString&)));
+    connect(this, &MyInteractor::askForWorkingDirectoryPath, this, [this] () { return ((MyFileManager*)fileManager())->workingDirectory(); });
+    connect(this, &MyInteractor::askForSettingWorkingDirectoryPath, this, [this] (const QString& workingDirectoryPath) { ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(workingDirectoryPath).absolutePath()); });
 }
 
 QList<QAbstractButton*> MyInteractor::getToolBarMenuButtons() {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -991,7 +991,7 @@ void MyInteractor::readFromFile(MyPluginItemBase* importTool) {
         ((MyFileManager*)fileManager())->setCurrentExportToolCompatibleWithImportTool(importTool);
         ((MyFileManager*)fileManager())->setCurrentFileName(fileName);
         ((MyFileManager*)fileManager())->setLastSavedFileName(fileName);
-        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath());
+        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath() + "/");
     }
 }
 
@@ -1017,7 +1017,7 @@ void MyInteractor::writeDataToFile(MyPluginItemBase* exportTool, const QString& 
         ((MyFileManager*)fileManager())->setCurrentExportTool(exportTool);
         ((MyFileManager*)fileManager())->setCurrentFileName(fileName);
         ((MyFileManager*)fileManager())->setLastSavedFileName(fileName);
-        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath());
+        ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(fileName).absolutePath() + "/");
     }
     ((MyDataExportTool*)exportTool)->showMessages();
 }
@@ -1087,7 +1087,7 @@ void MyInteractor::setFileManager() {
     _fileManager = new MyFileManager(getPluginsOfType(plugins(), "importtool"), getPluginsOfType(plugins(), "dataexporttool"));
     connect(_fileManager, SIGNAL(currentFileNameIsUpdated(const QString&)), this, SIGNAL(currentFileNameIsUpdated(const QString&)));
     connect(this, &MyInteractor::askForWorkingDirectoryPath, this, [this] () { return ((MyFileManager*)fileManager())->workingDirectory(); });
-    connect(this, &MyInteractor::askForSettingWorkingDirectoryPath, this, [this] (const QString& workingDirectoryPath) { ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(workingDirectoryPath).absolutePath()); });
+    connect(this, &MyInteractor::askForSettingWorkingDirectoryPath, this, [this] (const QString& workingDirectoryPath) { ((MyFileManager*)fileManager())->setWorkingDirectory(QFileInfo(workingDirectoryPath).absolutePath() + "/"); });
 }
 
 QList<QAbstractButton*> MyInteractor::getToolBarMenuButtons() {

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -116,6 +116,8 @@ signals:
     void elementsCopyableStatusChanged(const bool&);
     void pasteElementsStatusChanged(const bool&);
     void askForDisplaySceneContextMenu(const QPointF&);
+    QString askForWorkingDirectoryPath();
+    void askForSettingWorkingDirectoryPath(const QString&);
 
     void enterKeyIsPressed();
     

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -9,6 +9,7 @@
 
 #include <QGridLayout>
 #include <QSettings>
+#include <QStandardPaths>
 
 // MyNetworkEditorWidget
 
@@ -16,7 +17,6 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     setObjectName("main_widget");
     setStyleSheet("QFrame {background-color : white}");
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    readSettings();
 
     setWidgets();
     setInteractions();
@@ -31,6 +31,7 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     setLayout(layout);
     arrangeWidgetLayers();
 
+    readSettings();
     setReadyToLaunch();
 }
 
@@ -247,21 +248,37 @@ void MyNetworkEditorWidget::setReadyToLaunch() {
 void MyNetworkEditorWidget::readSettings() {
     QSettings settings("MyCompany", "NetworkEditorGUI");
     settings.beginGroup("NetworkEditorWidget");
-    const auto geometry1 = settings.value("geometry", QByteArray()).toByteArray();
-    if (geometry1.isEmpty())
+
+    // window size
+    const auto geometry = settings.value("geometry", QByteArray()).toByteArray();
+    if (geometry.isEmpty())
         setGeometry(200, 200, 1050, 700);
     else
-        restoreGeometry(geometry1);
+        restoreGeometry(geometry);
+
+    // working directory
+    const auto workingDirectory = settings.value("working directory", QByteArray()).toByteArray();
+    if (workingDirectory.isEmpty())
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    else
+        ((MyInteractor*)interactor())->askForSettingWorkingDirectoryPath(workingDirectory);
+
     settings.endGroup();
 }
 
 void MyNetworkEditorWidget::writeSettings() {
     QSettings settings("MyCompany", "NetworkEditorGUI");
     settings.beginGroup("NetworkEditorWidget");
+
+    // window size
     if (dynamic_cast<QWidget*>(parent()))
         settings.setValue("geometry", ((QWidget*)parent())->saveGeometry());
     else
         settings.setValue("geometry", saveGeometry());
+
+    // working directory
+    settings.setValue("working directory", ((MyInteractor*)interactor())->askForWorkingDirectoryPath());
+
     settings.endGroup();
 }
 

--- a/src/negui_parameters.cpp
+++ b/src/negui_parameters.cpp
@@ -1026,7 +1026,6 @@ void MyHorizontalAlignmentParameter::reset() {
 MyVerticalAlignmentParameter::MyVerticalAlignmentParameter() : MyNominalParameter("vertical-alignment", "Text \"Vertical Alignment\"") {
     _items.push_back("top");
     _items.push_back("middle");
-    _items.push_back("baseline");
     _items.push_back("bottom");
     reset();
 }
@@ -1036,8 +1035,6 @@ const Qt::Alignment MyVerticalAlignmentParameter::defaultAlignment() const {
         return Qt::AlignTop;
     else if (defaultValue() == "middle")
         return Qt::AlignVCenter;
-    else if (defaultValue() == "baseline")
-        return Qt::AlignBaseline;
     else if (defaultValue() == "bottom")
         return Qt::AlignBottom;
 

--- a/src/negui_text_style.cpp
+++ b/src/negui_text_style.cpp
@@ -152,11 +152,9 @@ const qreal MyTextStyleBase::verticalPadding() const {
     QFontMetrics fontMetrics(font());
     if (height() > fontMetrics.height()) {
         if (verticalAlignment() == Qt::AlignVCenter)
-            return 0.5 * height() - 0.75 * fontMetrics.height();
-        else if (verticalAlignment() == Qt::AlignBaseline)
-            return 0.5 * height() - 0.5 * fontMetrics.height();
+            return 0.5 * height() - fontMetrics.height();
         else if (verticalAlignment() == Qt::AlignBottom)
-            return height() - 1.5 * fontMetrics.height();
+            return height() - 2 * fontMetrics.height();
     }
     
     return 0.000;

--- a/src/negui_text_style.cpp
+++ b/src/negui_text_style.cpp
@@ -1,6 +1,8 @@
 #include "negui_text_style.h"
 #include <QJsonObject>
 
+#include "math.h"
+
 // MyTextStyleBase
 
 MyTextStyleBase::MyTextStyleBase(const QString& name) : My2DShapeStyleBase(name) {
@@ -152,12 +154,23 @@ const qreal MyTextStyleBase::verticalPadding() const {
     QFontMetrics fontMetrics(font());
     if (height() > fontMetrics.height()) {
         if (verticalAlignment() == Qt::AlignVCenter)
-            return 0.5 * height() - fontMetrics.height();
+            return 0.5 * height() - 0.5 * fontMetrics.height() - calculateTopPaddingRatioToFontHeight(font().pointSize()) * fontMetrics.height();
         else if (verticalAlignment() == Qt::AlignBottom)
             return height() - 2 * fontMetrics.height();
     }
-    
+
     return 0.000;
+}
+
+const qreal MyTextStyleBase::calculateTopPaddingRatioToFontHeight(const qreal& pointSize) const {
+    qreal topPaddingRatioToFontHeight = 1;
+    if (pointSize > 3) {
+        qreal numberOfStepsBaseFontSizeIsDoubled = log2(pointSize / 3.0);
+        for (int i = 0; i < numberOfStepsBaseFontSizeIsDoubled; i++)
+            topPaddingRatioToFontHeight -= 0.4 / pow(2, i);
+    }
+
+    return topPaddingRatioToFontHeight;
 }
 
 void MyTextStyleBase::read(const QJsonObject &json) {

--- a/src/negui_text_style.cpp
+++ b/src/negui_text_style.cpp
@@ -153,10 +153,20 @@ const Qt::Alignment MyTextStyleBase::verticalAlignment() const {
 const qreal MyTextStyleBase::verticalPadding() const {
     QFontMetrics fontMetrics(font());
     if (height() > fontMetrics.height()) {
-        if (verticalAlignment() == Qt::AlignVCenter)
+        if (verticalAlignment() == Qt::AlignVCenter) {
+#if defined(Q_OS_WIN)
+            return 0.5 * height() - 0.375 * fontMetrics.height() - calculateTopPaddingRatioToFontHeight(font().pointSize()) * fontMetrics.height();
+#elif defined(Q_OS_MAC)
             return 0.5 * height() - 0.5 * fontMetrics.height() - calculateTopPaddingRatioToFontHeight(font().pointSize()) * fontMetrics.height();
-        else if (verticalAlignment() == Qt::AlignBottom)
+#endif
+        }
+        else if (verticalAlignment() == Qt::AlignBottom) {
+#if defined(Q_OS_WIN)
+            return height() - 1.5 * fontMetrics.height();
+#elif defined(Q_OS_MAC)
             return height() - 2 * fontMetrics.height();
+#endif
+        }
     }
 
     return 0.000;

--- a/src/negui_text_style.h
+++ b/src/negui_text_style.h
@@ -56,6 +56,8 @@ public:
 
     const qreal verticalPadding() const;
 
+    const qreal calculateTopPaddingRatioToFontHeight(const qreal& pointSize) const ;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 


### PR DESCRIPTION
- node text vertical alignemnt is fixed so that it placed right in the middle of its node in center alignmnet

- aligning text at the center now uses some calculations to consider the padding imposed by qt at the top

- text baseline alignment is now deprecated and no longer is used

This PR fixes #84 