### PR TITLE
Panning window feature is added

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(source_files
 		negui_main_widget.cpp
 		negui_toolbar.cpp
 		negui_graphics_view.cpp
+		negui_secondary_graphics_view.cpp
 		negui_graphics_scene.cpp
 		negui_status_bar.cpp
 		negui_scene_mode_element_base.cpp
@@ -91,6 +92,7 @@ set(header_files
         negui_main_widget.h
 		negui_toolbar.h
 		negui_graphics_view.h
+		negui_secondary_graphics_view.h
 		negui_graphics_scene.h
 		negui_status_bar.h
 		negui_scene_mode_element_base.h

--- a/src/negui_graphics_scene.cpp
+++ b/src/negui_graphics_scene.cpp
@@ -2,13 +2,15 @@
 #include "negui_context_menu.h"
 
 #include <QColorDialog>
+#include <QGraphicsRectItem>
 
 // MyGraphicsScene
 
 MyGraphicsScene::MyGraphicsScene(QWidget* parent) : QGraphicsScene(parent) {
-    setSceneRect(-10000, -10000, 20000, 20000);
+    setSceneRect(-7500, -7500, 15000, 15000);
     _isLeftButtonPressed = false;
     _isShiftModifierPressed = false;
+    _viewFrameGraphicsItem = NULL;
     clearScene();
 }
 
@@ -45,6 +47,19 @@ void MyGraphicsScene::setBackgroundColor(const QString &backgroundColor) {
 void MyGraphicsScene::clearScene() {
     clear();
     setBackgroundColor("white");
+    _viewFrameGraphicsItem = NULL;
+}
+
+void MyGraphicsScene::updateViewFrame(const QRectF& viewRect) {
+    if (_viewFrameGraphicsItem)
+        ((QGraphicsRectItem*)_viewFrameGraphicsItem)->setRect(viewRect.x() - 25, viewRect.y() - 25, viewRect.width() + 50, viewRect.height() + 50);
+    else {
+        _viewFrameGraphicsItem = new QGraphicsRectItem(viewRect.x() - 25, viewRect.y() - 25, viewRect.width() + 50, viewRect.height() + 50);
+        QPen pen(Qt::black);
+        pen.setWidth(50);
+        ((QGraphicsRectItem*)_viewFrameGraphicsItem)->setPen(pen);
+        addItem(_viewFrameGraphicsItem);
+    }
 }
 
 QList<QGraphicsItem *> MyGraphicsScene::itemsAtPosition(const QPointF& position) {

--- a/src/negui_graphics_scene.h
+++ b/src/negui_graphics_scene.h
@@ -19,6 +19,8 @@ public:
     QMenu* createContextMenu();
 
     void connectContextMenu(QMenu* contextMenu);
+
+    void updateViewFrame(const QRectF& viewRect);
     
 signals:
 
@@ -67,6 +69,7 @@ protected:
     bool _isShiftModifierPressed;
     bool _whetherMouseReleaseEventIsAccepted;
     QPointF _cursorPosition;
+    QGraphicsItem* _viewFrameGraphicsItem;
 };
 
 #endif

--- a/src/negui_graphics_view.cpp
+++ b/src/negui_graphics_view.cpp
@@ -14,7 +14,7 @@ MyGraphicsView::MyGraphicsView(QWidget* parent) : QGraphicsView(parent) {
     setStyle(new MyProxyStyle(style()));
     setMouseTracking(true);
     
-    _minScale = 1.0 / 10.0;
+    _minScale = 1.5 / 10.0;
     _maxScale = 10.0;
     _numScheduledScalings = 0;
     _panMode = false;
@@ -24,6 +24,9 @@ MyGraphicsView::MyGraphicsView(QWidget* parent) : QGraphicsView(parent) {
     setScene(new MyGraphicsScene(this));
     setSceneRect(scene()->sceneRect().x(), scene()->sceneRect().y(), scene()->sceneRect().width(), scene()->sceneRect().height());
     connect(this, SIGNAL(askForDisplayContextMenu(const QPointF&)), scene(), SLOT(displayContextMenu(const QPointF&)));
+    connect(horizontalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(updateFrame()));
+    connect(verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(updateFrame()));
+
     setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     resetScale();
 };
@@ -125,6 +128,15 @@ void MyGraphicsView::zoom(const qreal factor) {
                               transform().m31(), transform().m32(), transform().m33());
     setTransform(transformMatrix);
     emit scaleChanged(currentScale());
+    updateFrame();
+}
+
+void MyGraphicsView::updateFrame() {
+    ((MyGraphicsScene*)scene())->updateViewFrame(mapToScene(viewport()->geometry()).boundingRect());
+}
+
+void MyGraphicsView::updateFrame(const QRectF& frameRect) {
+    ((MyGraphicsScene*)scene())->updateViewFrame(frameRect);
 }
 
 void MyGraphicsView::wheelEvent(QWheelEvent * event) {
@@ -186,6 +198,11 @@ void MyGraphicsView::keyPressEvent(QKeyEvent *event) {
 void MyGraphicsView::leaveEvent(QEvent *event) {
     emit mouseLeft();
     QGraphicsView::leaveEvent(event);
+}
+
+void MyGraphicsView::resizeEvent(QResizeEvent *event) {
+    QGraphicsView::resizeEvent(event);
+    updateFrame();
 }
 
 // MyProxyStyle

--- a/src/negui_graphics_view.h
+++ b/src/negui_graphics_view.h
@@ -28,6 +28,7 @@ public:
     void exportFigureAsSVG(const QString& fileName ,const QRectF& pageRect);
     
 signals:
+
     void enterKeyIsPressed();
     void askForDisplayContextMenu(const QPointF& position);
     void mouseLeft();
@@ -37,6 +38,8 @@ public slots:
 
     void zoomIn();
     void zoomOut();
+    void updateFrame();
+    void updateFrame(const QRectF& frameRect);
     
 private slots:
     
@@ -53,6 +56,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     void leaveEvent(QEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
     qint32 _numScheduledScalings;
     qreal _minScale;

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -250,8 +250,8 @@ void MyInteractor::saveCurrentNetwork() {
 }
 
 void MyInteractor::resetNetworkCanvas() {
-    resetCanvas();
     resetNetwork();
+    resetCanvas();
 }
 
 void MyInteractor::resetCanvas() {

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -3,11 +3,13 @@
 #include "negui_toolbar.h"
 #include "negui_mode_menu.h"
 #include "negui_graphics_view.h"
+#include "negui_secondary_graphics_view.h"
 #include "negui_graphics_scene.h"
 #include "negui_status_bar.h"
 #include "negui_null_feature_menu.h"
 
 #include <QGridLayout>
+#include <QStackedLayout>
 #include <QSettings>
 #include <QStandardPaths>
 
@@ -26,7 +28,11 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     layout->addWidget(toolBar(), layout->rowCount(), 0, 1, 3);
     _layoutMenuRow = layout->rowCount();
     layout->addWidget(modeMenu(), layout->rowCount(), 0, Qt::AlignTop | Qt::AlignLeft);
-    layout->addWidget(view(), layout->rowCount() - 1, 1);
+    QStackedLayout* stackedLayout = new QStackedLayout();
+    stackedLayout->setStackingMode(QStackedLayout::StackAll);
+    stackedLayout->addWidget(view());
+    stackedLayout->addWidget(secondaryView());
+    layout->addLayout(stackedLayout, layout->rowCount() - 1, 1);
     layout->addWidget(statusBar(), layout->rowCount(), 0, 1, 3);
     setLayout(layout);
     arrangeWidgetLayers();
@@ -44,6 +50,7 @@ void MyNetworkEditorWidget::setWidgets() {
     _statusBar = new MyStatusBar(this);
     _modeMenu = new MyFrequentlyUsedButtonsModeMenu(this);
     _view = new MyGraphicsView(this);
+    _secondaryView = new MySecondaryGraphicsView(((MyGraphicsView*)view())->scene());
     _interactor = new MyInteractor(this);
     _featureMenu = NULL;
 
@@ -134,6 +141,7 @@ void MyNetworkEditorWidget::setInteractions() {
 
     // reset scene
     connect((MyInteractor*)interactor(), SIGNAL(askForClearScene()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(clearScene()));
+    connect((MyInteractor*)interactor(), SIGNAL(askForClearScene()), this, SLOT(removeFeatureMenu()));
     
     // items at position
     connect((MyInteractor*)interactor(), SIGNAL(askForItemsAtPosition(const QPointF&)), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(itemsAtPosition(const QPointF&)));
@@ -209,6 +217,10 @@ QWidget* MyNetworkEditorWidget::modeMenu() {
 
 QWidget* MyNetworkEditorWidget::view() {
     return _view;
+}
+
+QWidget* MyNetworkEditorWidget::secondaryView() {
+    return _secondaryView;
 }
 
 QWidget* MyNetworkEditorWidget::statusBar() {

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -9,7 +9,6 @@
 #include "negui_null_feature_menu.h"
 
 #include <QGridLayout>
-#include <QStackedLayout>
 #include <QSettings>
 #include <QStandardPaths>
 
@@ -28,11 +27,8 @@ MyNetworkEditorWidget::MyNetworkEditorWidget(QWidget *parent) :  QFrame(parent) 
     layout->addWidget(toolBar(), layout->rowCount(), 0, 1, 3);
     _layoutMenuRow = layout->rowCount();
     layout->addWidget(modeMenu(), layout->rowCount(), 0, Qt::AlignTop | Qt::AlignLeft);
-    QStackedLayout* stackedLayout = new QStackedLayout();
-    stackedLayout->setStackingMode(QStackedLayout::StackAll);
-    stackedLayout->addWidget(view());
-    stackedLayout->addWidget(secondaryView());
-    layout->addLayout(stackedLayout, layout->rowCount() - 1, 1);
+    layout->addWidget(view(), layout->rowCount() - 1, 1);
+    layout->addWidget(secondaryView(), layout->rowCount() - 1, 1, Qt::AlignBottom | Qt::AlignRight);
     layout->addWidget(statusBar(), layout->rowCount(), 0, 1, 3);
     setLayout(layout);
     arrangeWidgetLayers();

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -17,6 +17,7 @@ public:
     QWidget* toolBar();
     QWidget* modeMenu();
     QWidget* view();
+    QWidget* secondaryView();
     QWidget* statusBar();
     QWidget* featureMenu();
     void readSettings();
@@ -64,6 +65,7 @@ protected:
     QObject* _interactor;
     QWidget* _toolBar;
     QWidget* _view;
+    QWidget* _secondaryView;
     QWidget* _modeMenu;
     QWidget* _featureMenu;
     QWidget* _statusBar;

--- a/src/negui_secondary_graphics_view.cpp
+++ b/src/negui_secondary_graphics_view.cpp
@@ -1,0 +1,26 @@
+#include "negui_secondary_graphics_view.h"
+#include "negui_graphics_scene.h"
+
+// MySecondaryGraphicsView
+
+MySecondaryGraphicsView::MySecondaryGraphicsView(QGraphicsScene* mainScene, QWidget* parent) : QGraphicsView(parent) {
+    setFrameShape(Box);
+    setStyleSheet("QFrame {border: 1px solid gray; border-radius: 2px solid gray;}");
+    setContentsMargins(0, 0, 0, 0);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    setInteractive(false);
+    setScene(mainScene);
+    setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
+    setSceneRect(scene()->sceneRect());
+    adjustScale();
+    setFixedSize(200, 200);
+};
+
+void MySecondaryGraphicsView::adjustScale() {
+    QTransform transformMatrix = transform();
+    transformMatrix.setMatrix(transform().m11() - 0.9875, transform().m12(), transform().m13(),
+                              transform().m21(), transform().m22() - 0.9875, transform().m23(),
+                              transform().m31(), transform().m32(), transform().m33());
+    setTransform(transformMatrix);
+}
+

--- a/src/negui_secondary_graphics_view.h
+++ b/src/negui_secondary_graphics_view.h
@@ -1,0 +1,16 @@
+#ifndef __NEGUI_SECONDARY_GRAPHICS_VIEW_H
+#define __NEGUI_SECONDARY_GRAPHICS_VIEW_H
+
+#include <QGraphicsView>
+
+class MySecondaryGraphicsView : public QGraphicsView {
+    Q_OBJECT
+
+public:
+
+    MySecondaryGraphicsView(QGraphicsScene* mainScene, QWidget* parent = nullptr);
+
+    void adjustScale();
+};
+
+#endif


### PR DESCRIPTION
-   secondary graphics view, a small representative for the main graphics view, is added

- view frame,  a frame around the main graphics view, is displayed in the secondary graphics view

- the secondary graphics view is added on top of the main graphics view in the main widget layout

- graphics scene rect dimensions are reduced

- when asking for clear scene signal is emitted, remove feature menu slot is called

This PR fixes #86, fixes #89, and fixes #103 issues