### PR TITLE
Node parenting is updated

### DIFF
--- a/src/negui_graphics_scene.cpp
+++ b/src/negui_graphics_scene.cpp
@@ -10,6 +10,7 @@ MyGraphicsScene::MyGraphicsScene(QWidget* parent) : QGraphicsScene(parent) {
     setSceneRect(-7500, -7500, 15000, 15000);
     _isLeftButtonPressed = false;
     _isShiftModifierPressed = false;
+    _isControlModifierPressed = false;
     _viewFrameGraphicsItem = NULL;
     clearScene();
 }
@@ -68,6 +69,10 @@ QList<QGraphicsItem *> MyGraphicsScene::itemsAtPosition(const QPointF& position)
 
 const bool MyGraphicsScene::isShiftModifierPressed() {
     return _isShiftModifierPressed;
+}
+
+const bool MyGraphicsScene::isControlModifierPressed() {
+    return _isControlModifierPressed;
 }
 
 QMenu* MyGraphicsScene::createContextMenu() {
@@ -170,6 +175,8 @@ void MyGraphicsScene::keyPressEvent(QKeyEvent *event) {
                 emit askForPasteCopiedNetworkElements(_cursorPosition);
             else if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace)
                 emit askForDeleteSelectedNetworkElements();
+            else if (event->modifiers() == Qt::ControlModifier)
+                _isControlModifierPressed = true;
         }
     }
 }
@@ -179,6 +186,10 @@ void MyGraphicsScene::keyReleaseEvent(QKeyEvent *event) {
     if (!event->isAccepted()) {
         if (event->key() == Qt::Key_Shift) {
             _isShiftModifierPressed = false;
+            event->accept();
+        }
+        else if (event->key() == Qt::Key_Control) {
+            _isControlModifierPressed = false;
             event->accept();
         }
     }

--- a/src/negui_graphics_scene.h
+++ b/src/negui_graphics_scene.h
@@ -54,6 +54,7 @@ public slots:
     void clearScene();
     QList<QGraphicsItem *> itemsAtPosition(const QPointF& position);
     const bool isShiftModifierPressed();
+    const bool isControlModifierPressed();
     void displayContextMenu(const QPointF& position);
     const bool whetherMouseReleaseEventIsAccepted();
     
@@ -67,6 +68,7 @@ protected:
 
     bool _isLeftButtonPressed;
     bool _isShiftModifierPressed;
+    bool _isControlModifierPressed;
     bool _whetherMouseReleaseEventIsAccepted;
     QPointF _cursorPosition;
     QGraphicsItem* _viewFrameGraphicsItem;

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -313,6 +313,7 @@ void MyInteractor::addNode(MyNetworkElementBase* n) {
         connect(n, SIGNAL(askForIconsDirectoryPath()), this, SLOT(iconsDirectoryPath()));
         connect(n, SIGNAL(positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&)), this, SLOT(moveSelectedNetworkElements(MyNetworkElementBase*, const QPointF&)));
         connect(n, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
+        connect(n, SIGNAL(askForWhetherControlModifierIsPressed()), this, SIGNAL(askForWhetherControlModifierIsPressed()));
         connect(n->graphicsItem(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
         connect(n->graphicsItem(), SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
         connect(this, SIGNAL(askForAdjustConnectedEdgesOfNodes()), n, SLOT(adjustConnectedEdges()));

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -295,10 +295,11 @@ void MyInteractor::addNode(MyNetworkElementBase* n) {
         _nodes.push_back(n);
         n->setActive(true);
         n->updateGraphicsItem();
-        connect(n, SIGNAL(askForParentNodeAtPosition(MyNetworkElementBase*, const QPointF&)), this, SLOT(parentNodeAtPosition(MyNetworkElementBase*, const QPointF&)));
         connect(n, SIGNAL(askForSelectNetworkElement(MyNetworkElementBase*)), this, SLOT(selectElement(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForSelectNetworkElement(MyNetworkElementBase*)), this, SLOT(addNewEdge(MyNetworkElementBase*)));
         connect(n, SIGNAL(askForDeleteNetworkElement(MyNetworkElementBase*)), this, SLOT(deleteNode(MyNetworkElementBase*)));
+        connect(n, &MyNetworkElementBase::askForListOfElements, this, [this] () { return nodes() + edges(); } );
+        connect(n, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
         connect(n, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
         connect(n, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SLOT(displayFeatureMenu(QWidget*)));
         connect(n, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
@@ -344,26 +345,6 @@ void MyInteractor::updateNodeParents() {
         if (parentNode)
             ((MyNodeBase*)node)->setParentNode((MyNodeBase*)parentNode);
     }
-}
-
-MyNetworkElementBase* MyInteractor::parentNodeAtPosition(MyNetworkElementBase* currentNode, const QPointF& position) {
-    QList<QGraphicsItem *> items = askForItemsAtPosition(position);
-    MyNetworkElementBase* parentNode = NULL;
-    qint32 parentNodeZValue = INT_MIN;
-    for (QGraphicsItem* item : qAsConst(items)) {
-        if (item->parentItem()) {
-            for (MyNetworkElementBase* node : qAsConst(nodes())) {
-                if (node->graphicsItem() == item->parentItem() && node != currentNode) {
-                    if (item->parentItem()->zValue() > parentNodeZValue) {
-                        parentNode = node;
-                        parentNodeZValue = item->parentItem()->zValue();
-                    }
-                }
-            }
-        }
-    }
-
-    return parentNode;
 }
 
 void MyInteractor::clearNodesInfo() {
@@ -441,6 +422,8 @@ void MyInteractor::addEdge(MyNetworkElementBase* e) {
         e->updateGraphicsItem();
         connect(e, SIGNAL(askForSelectNetworkElement(MyNetworkElementBase*)), this, SLOT(selectElement(MyNetworkElementBase*)));
         connect(e, SIGNAL(askForDeleteNetworkElement(MyNetworkElementBase*)), this, SLOT(deleteEdge(MyNetworkElementBase*)));
+        connect(e, &MyNetworkElementBase::askForListOfElements, this, [this] () { return nodes() + edges(); } );
+        connect(e, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
         connect(e, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
         connect(e, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SLOT(displayFeatureMenu(QWidget*)));
         connect(e, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -112,6 +112,7 @@ signals:
     void modeIsSet(const QString&);
     void currentFileNameIsUpdated(const QString&);
     const bool askForWhetherShiftModifierIsPressed();
+    const bool askForWhetherControlModifierIsPressed();
     QRectF askForItemsBoundingRect();
     void elementsCuttableStatusChanged(const bool&);
     void elementsCopyableStatusChanged(const bool&);

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -200,7 +200,6 @@ private slots:
     void writeFigureToFile(const QString& exportToolName);
     void writeFigureToFile(MyPluginItemBase* exportTool);
     void autoLayout(MyPluginItemBase* autoLayoutEngine);
-    MyNetworkElementBase* parentNodeAtPosition(MyNetworkElementBase* currentNode, const QPointF& position);
     void createChangeStageCommand();
     void createSelectionAreaGraphicsItem(const QPointF& position);
     void selectSelectionAreaCoveredNodes();

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -145,7 +145,10 @@ void MyNetworkEditorWidget::setInteractions() {
     // activated shift modifier
     connect((MyInteractor*)interactor(), SIGNAL(askForWhetherShiftModifierIsPressed()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(isShiftModifierPressed()));
 
-    // activated shift modifier
+    // activated control modifier
+    connect((MyInteractor*)interactor(), SIGNAL(askForWhetherControlModifierIsPressed()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(isControlModifierPressed()));
+
+    // items bounding rect
     connect((MyInteractor*)interactor(), &MyInteractor::askForItemsBoundingRect, ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), [this] () { return ((MyGraphicsScene*)((MyGraphicsView*)view())->scene())->itemsBoundingRect(); });
 
     // select all

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -113,6 +113,8 @@ signals:
 
     void askForDisplaySceneContextMenu(const QPointF&);
 
+    const bool askForWhetherControlModifierIsPressed();
+
 public slots:
 
     virtual void setSelected(const bool& selected);

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -82,6 +82,10 @@ public:
 signals:
     
     void askForSelectNetworkElement(MyNetworkElementBase*);
+
+    QList<MyNetworkElementBase*> askForListOfElements();
+
+    QList<QGraphicsItem*> askForItemsAtPosition(const QPointF&);
     
     void askForCreateChangeStageCommand();
 

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -78,7 +78,7 @@ void MyNodeBase::deparent() {
 }
 
 void MyNodeBase::reparent() {
-    MyNetworkElementBase* parentNode = askForParentNodeAtPosition(this, position());
+    MyNetworkElementBase* parentNode = getParentNodeAtPosition(position());
     deparent();
     if (parentNode && ((MyComplexClassicNodeStyle*)parentNode->style())->isConvertibleToParentCategory(((MyNodeStyleBase*)style())->parentCategories())) {
         ((MyComplexClassicNodeStyle*)parentNode->style())->convertToParentCategory();
@@ -87,6 +87,29 @@ void MyNodeBase::reparent() {
         resetPosition();
         setConnectedNodesParents();
     }
+}
+
+MyNetworkElementBase* MyNodeBase::getParentNodeAtPosition(const QPointF& position) {
+    QList<QGraphicsItem *> items = askForItemsAtPosition(position);
+    MyNetworkElementBase* parentNode = NULL;
+    qint32 parentNodeZValue = INT_MIN;
+    for (QGraphicsItem* item : qAsConst(items)) {
+        if (item->parentItem()) {
+            QList<MyNetworkElementBase*> elements = askForListOfElements();
+            for (MyNetworkElementBase* element : elements) {
+                if (element->type() == MyNetworkElementBase::NODE_ELEMENT) {
+                    if (element->graphicsItem() == item->parentItem() && element != this) {
+                        if (item->parentItem()->zValue() > parentNodeZValue) {
+                            parentNode = element;
+                            parentNodeZValue = item->parentItem()->zValue();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return parentNode;
 }
 
 void MyNodeBase::setPosition(const QPointF& position) {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -26,8 +26,7 @@ MyNodeBase::ELEMENT_TYPE MyNodeBase::type() {
 void MyNodeBase::connectGraphicsItem() {
     MyNetworkElementBase::connectGraphicsItem();
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit askForSelectNetworkElement(this); });
-    connect(_graphicsItem, SIGNAL(askForDeparent()), this,  SLOT(deparent()));
-    connect(_graphicsItem, SIGNAL(askForReparent()), this, SLOT(reparent()));
+    connect(_graphicsItem, SIGNAL(askForUpdateParentNode()), this,  SLOT(updateParentNode()));
     connect(_graphicsItem, SIGNAL(askForResetPosition()), this, SLOT(resetPosition()));
     connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedEdges()));
     connect((MyNodeSceneGraphicsItemBase*)_graphicsItem, &MyNodeSceneGraphicsItemBase::positionChangedByMouseMoveEvent, this, [this] (const QPointF& movedDistance) { positionChangedByMouseMoveEvent(this, movedDistance); });
@@ -72,20 +71,22 @@ const bool MyNodeBase::isCuttable() {
     return true;
 }
 
-void MyNodeBase::deparent() {
-    unsetParentNode();
-    setConnectedNodesParents();
-}
-
-void MyNodeBase::reparent() {
+void MyNodeBase::updateParentNode() {
     MyNetworkElementBase* parentNode = getParentNodeAtPosition(position());
-    deparent();
-    if (parentNode && ((MyComplexClassicNodeStyle*)parentNode->style())->isConvertibleToParentCategory(((MyNodeStyleBase*)style())->parentCategories())) {
-        ((MyComplexClassicNodeStyle*)parentNode->style())->convertToParentCategory();
+    if (!parentNode || parentNode != _parentNode) {
+        unsetParentNode();
+        setConnectedNodesParents();
+        emit parentNodeIsUpdated();
+    }
+
+    if (parentNode && !_parentNode && ((MyClassicNodeStyleBase*)parentNode->style())->isConvertibleToParentCategory(((MyNodeStyleBase*)style())->parentCategories())) {
+        ((MyClassicNodeStyleBase*)parentNode->style())->convertToParentCategory();
         setParentNode((MyNodeBase*)parentNode);
-        ((MyComplexClassicNode*)parentNode)->adjustExtents();
+        if (askForWhetherControlModifierIsPressed())
+            ((MyClassicNodeBase*)parentNode)->adjustExtents();
         resetPosition();
         setConnectedNodesParents();
+        emit parentNodeIsUpdated();
     }
 }
 
@@ -112,23 +113,6 @@ MyNetworkElementBase* MyNodeBase::getParentNodeAtPosition(const QPointF& positio
     return parentNode;
 }
 
-void MyNodeBase::setPosition(const QPointF& position) {
-    // position
-    _position = position;
-
-    // adjust parent extents
-    if (!isParentNodeLocked()) {
-        if (parentNode())
-            ((MyComplexClassicNode*)parentNode())->adjustExtents();
-    }
-    else
-        lockParentNode(false);
-
-    // edges
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
-        ((MyEdgeBase*)edge)->updatePoints();
-}
-
 const QString& MyNodeBase::parentNodeId() const {
     return _parentNodeId;
 }
@@ -145,14 +129,15 @@ void MyNodeBase::setParentNode(MyNetworkElementBase* parentNode) {
     _parentNode = parentNode;
     _isSetParentNode = true;
     _parentNodeId = parentNode->name();
-    ((MyComplexClassicNode*)_parentNode)->addChildNode(this);
+    ((MyClassicNodeBase*)_parentNode)->addChildNode(this);
     graphicsItem()->setZValue(calculateZValue());
 }
 
 void MyNodeBase::unsetParentNode() {
     if (_parentNode) {
-        ((MyComplexClassicNode*)_parentNode)->removeChildNode(this);
-        ((MyComplexClassicNode*)_parentNode)->adjustExtents();
+        ((MyClassicNodeBase*)_parentNode)->removeChildNode(this);
+        if (askForWhetherControlModifierIsPressed())
+            ((MyClassicNodeBase*)_parentNode)->adjustExtents();
     }
     _parentNode = NULL;
     _isSetParentNode = false;
@@ -164,12 +149,32 @@ void MyNodeBase::lockParentNode(const bool& locked) {
     _isParentNodeLocked = locked;
 }
 
-void MyNodeBase::resetPosition() {
-    setPosition(((MyNodeSceneGraphicsItemBase*)graphicsItem())->getExtents().center());
-}
-
 const QPointF MyNodeBase::position() const {
     return _position;
+}
+
+void MyNodeBase::setPosition(const QPointF& position) {
+    // position
+    _position = position;
+
+    // adjust parent extents
+    if (!isParentNodeLocked()) {
+        if (parentNode()) {
+            ((MyClassicNodeBase*)parentNode())->lockChildNodes(true);
+            if (askForWhetherControlModifierIsPressed())
+                ((MyClassicNodeBase*)parentNode())->adjustExtents();
+        }
+    }
+    else
+        lockParentNode(false);
+
+    // edges
+    for (MyNetworkElementBase *edge : qAsConst(edges()))
+        ((MyEdgeBase*)edge)->updatePoints();
+}
+
+void MyNodeBase::resetPosition() {
+    setPosition(((MyNodeSceneGraphicsItemBase*)graphicsItem())->getExtents().center());
 }
 
 const QRectF MyNodeBase::getExtents() {
@@ -186,7 +191,9 @@ void MyNodeBase::addParentFeaturesToFeatureMenu(QWidget* featureMenu) {
     if (!((MyNodeStyleBase*)style())->parentTitle().isEmpty())
         parentLabel = ((MyNodeStyleBase*)style())->parentTitle();
     contentLayout->addWidget(new MyLabel(parentLabel, parentLabel + " that encloses " + styleCategory()), contentLayout->rowCount(), 0, Qt::AlignLeft);
-    contentLayout->addWidget(new MyReadOnlyLineEdit(parentNodeId()), contentLayout->rowCount() - 1, 1, Qt::AlignRight);
+    QWidget* parentNodeLineEdit = new MyReadOnlyLineEdit(parentNodeId());
+    connect(this, &MyNodeBase::parentNodeIsUpdated, parentNodeLineEdit, [this, parentNodeLineEdit] () { ((MyReadOnlyLineEdit*)parentNodeLineEdit)->setText(parentNodeId()); });
+    contentLayout->addWidget(parentNodeLineEdit, contentLayout->rowCount() - 1, 1, Qt::AlignRight);
 }
 
 const qint32 MyNodeBase::calculateZValue() {
@@ -273,19 +280,14 @@ const bool MyClassicNodeBase::isCopyable() {
 }
 
 void MyClassicNodeBase::addChildNode(MyNetworkElementBase* n) {
-    if (n) {
+    if (n)
         _childNodes.push_back(n);
-        updateChildNodesMobility();
-    }
 }
 
 void MyClassicNodeBase::removeChildNode(MyNetworkElementBase* n) {
-    if (n) {
+    if (n)
         _childNodes.removeOne(n);
-        updateChildNodesMobility();
-    }
 }
-
 QList<MyNetworkElementBase*>& MyClassicNodeBase::childNodes() {
     return _childNodes;
 }
@@ -294,21 +296,12 @@ void MyClassicNodeBase::lockChildNodes(const bool& locked) {
     _areChildNodesLocked = locked;
 }
 
-void MyClassicNodeBase::updateChildNodesMobility() {
-    if (childNodes().size() > 1) {
-        for (MyNetworkElementBase* node : qAsConst(childNodes()))
-            node->graphicsItem()->setFlag(QGraphicsItem::ItemIsMovable, true);
-    }
-    else if (childNodes().size() == 1)
-        childNodes().first()->graphicsItem()->setFlag(QGraphicsItem::ItemIsMovable, false);
-}
-
 void MyClassicNodeBase::setPosition(const QPointF& position) {
     // move child nodes
     if (!areChildNodesLocked()) {
         for (MyNetworkElementBase* node : qAsConst(childNodes())) {
             ((MyNodeBase*)node)->lockParentNode(true);
-            ((MyComplexClassicNodeSceneGraphicsItem*)node->graphicsItem())->moveBy((position - _position).x(), (position - _position).y());
+            ((MyNodeSceneGraphicsItemBase*)node->graphicsItem())->moveBy((position - _position).x(), (position - _position).y());
             ((MyNodeBase*)node)->adjustConnectedEdges(true);
         }
     }
@@ -366,8 +359,8 @@ const QRectF MyClassicNodeBase::getExtents() {
 }
 
 const QRectF MyClassicNodeBase::createParentNodeExtentsRectangle(qreal extentsX, qreal extentsY, qreal extentsWidth, qreal extentsHeight) {
-    qreal minimumWidth = 400.0;
-    qreal minimumHeight = 300.0;
+    qreal minimumWidth = 150.0;
+    qreal minimumHeight = 120.0;
     if (childNodes().size() == 1) {
         if (extentsWidth < minimumWidth) {
             extentsX -= 0.5 * (minimumWidth - extentsWidth);
@@ -384,10 +377,9 @@ const QRectF MyClassicNodeBase::createParentNodeExtentsRectangle(qreal extentsX,
 
 void MyClassicNodeBase::adjustExtents() {
     QRectF extents = getExtents();
-    lockChildNodes(true);
-    ((MyComplexClassicNodeSceneGraphicsItem*)graphicsItem())->moveBy(extents.x() - (position().x() - 0.5 * extents.width()), extents.y() - (position().y() - 0.5 * extents.height()));
-    ((MyComplexClassicNodeSceneGraphicsItem*)graphicsItem())->updateExtents(extents);
-    ((MyComplexClassicNodeSceneGraphicsItem*)graphicsItem())->adjustOriginalPosition();
+    ((MyClassicNodeSceneGraphicsItemBase*)graphicsItem())->moveBy(extents.x() - (position().x() - 0.5 * extents.width()), extents.y() - (position().y() - 0.5 * extents.height()));
+    ((MyClassicNodeSceneGraphicsItemBase*)graphicsItem())->updateExtents(extents);
+    ((MyClassicNodeSceneGraphicsItemBase*)graphicsItem())->adjustOriginalPosition();
 }
 
 const qint32 MyClassicNodeBase::calculateNodeZValue() {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -26,7 +26,7 @@ MyNodeBase::ELEMENT_TYPE MyNodeBase::type() {
 void MyNodeBase::connectGraphicsItem() {
     MyNetworkElementBase::connectGraphicsItem();
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForSelectNetworkElement, this, [this] () { emit askForSelectNetworkElement(this); });
-    connect(_graphicsItem, SIGNAL(askForUpdateParentNode()), this,  SLOT(updateParentNode()));
+    connect(_graphicsItem, SIGNAL(askForUpdateParentNode()), this,  SLOT(updateSelectedNodesParentNode()));
     connect(_graphicsItem, SIGNAL(askForResetPosition()), this, SLOT(resetPosition()));
     connect(_graphicsItem, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(adjustConnectedEdges()));
     connect((MyNodeSceneGraphicsItemBase*)_graphicsItem, &MyNodeSceneGraphicsItemBase::positionChangedByMouseMoveEvent, this, [this] (const QPointF& movedDistance) { positionChangedByMouseMoveEvent(this, movedDistance); });
@@ -69,6 +69,14 @@ const bool MyNodeBase::isCuttable() {
     }
 
     return true;
+}
+
+void MyNodeBase::updateSelectedNodesParentNode() {
+    QList<MyNetworkElementBase*> elements = askForListOfElements();
+    for (MyNetworkElementBase* element : elements) {
+        if (element->type() == MyNetworkElementBase::NODE_ELEMENT && element->isSelected())
+            ((MyNodeBase*)element)->updateParentNode();
+    }
 }
 
 void MyNodeBase::updateParentNode() {

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -89,14 +89,13 @@ public:
 signals:
 
     void positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&);
+
+    void parentNodeIsUpdated();
     
 public slots:
     
-    // unset the parent of the node
-    void deparent();
-    
-    // set a new parent to the node
-    void reparent();
+    // update the parent node of the node
+    void updateParentNode();
 
     MyNetworkElementBase* getParentNodeAtPosition(const QPointF& position);
     
@@ -142,9 +141,6 @@ public:
 
     // lock the position of the child nodes
     void lockChildNodes(const bool& locked);
-
-    // set whether the child nodes are movable or not
-    void updateChildNodesMobility();
 
     // return true if the child nodes of the node are locked
     const bool areChildNodesLocked() const { return _areChildNodesLocked; }

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -93,6 +93,8 @@ signals:
     void parentNodeIsUpdated();
     
 public slots:
+
+    void updateSelectedNodesParentNode();
     
     // update the parent node of the node
     void updateParentNode();

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -87,8 +87,6 @@ public:
     void write(QJsonObject &json) override;
     
 signals:
-    
-    MyNetworkElementBase* askForParentNodeAtPosition(MyNetworkElementBase* currentNode, const QPointF& position);
 
     void positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&);
     
@@ -99,6 +97,8 @@ public slots:
     
     // set a new parent to the node
     void reparent();
+
+    MyNetworkElementBase* getParentNodeAtPosition(const QPointF& position);
     
     // set the position of the node using its current position
     void resetPosition();

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -33,8 +33,7 @@ MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position
     
     // make it focusable
     setFlag(QGraphicsItem::ItemIsFocusable, true);
-    
-    _reparent = false;
+
     connect(this, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(updateFocusedGraphicsItems()));
     
     setZValue(2);
@@ -80,8 +79,6 @@ void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
 
 QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, const QVariant &value) {
     if (change == ItemPositionChange) {
-        if (_reparent)
-            emit askForDeparent();
         moveChildItems(value.toPointF());
         emit askForResetPosition();
     }
@@ -89,31 +86,19 @@ QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, cons
     return QGraphicsItem::itemChange(change, value);
 }
 
+void MyNodeSceneGraphicsItemBase::moveBy(qreal dx, qreal dy) {
+    QGraphicsItem::moveBy(dx, dy);
+}
+
 void MyNodeSceneGraphicsItemBase::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     MyNetworkElementGraphicsItemBase::mouseMoveEvent(event);
     emit positionChangedByMouseMoveEvent(event->scenePos() - event->lastScenePos());
 }
 
-void MyNodeSceneGraphicsItemBase::keyPressEvent(QKeyEvent *event) {
-    QGraphicsItem::keyPressEvent(event);
-    if (!event->isAccepted()) {
-        if (event->key() == Qt::Key_Control) {
-            if (_isChosen)
-                _reparent = true;
-            event->accept();
-        }
-    }
-}
-
-void MyNodeSceneGraphicsItemBase::keyReleaseEvent(QKeyEvent *event) {
-    QGraphicsItem::keyReleaseEvent(event);
-    if (!event->isAccepted()) {
-        if (event->key() == Qt::Key_Control) {
-            emit askForReparent();
-            _reparent = false;
-            event->accept();
-        }
-    }
+void MyNodeSceneGraphicsItemBase::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
+    if (event->button() == Qt::LeftButton)
+        emit askForUpdateParentNode();
+    MyNetworkElementGraphicsItemBase::mouseReleaseEvent(event);
 }
 
 // MyClassicNodeSceneGraphicsItemBase

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -40,11 +40,6 @@ MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position
     setZValue(2);
 }
 
-void MyNodeSceneGraphicsItemBase::deparent() {
-    if (_reparent)
-        emit askForDeparent();
-}
-
 void MyNodeSceneGraphicsItemBase::moveChildItems(const QPointF& movedDistance) {
     for (QGraphicsItem* item : childItems()) {
         MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
@@ -85,7 +80,8 @@ void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
 
 QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, const QVariant &value) {
     if (change == ItemPositionChange) {
-        deparent();
+        if (_reparent)
+            emit askForDeparent();
         moveChildItems(value.toPointF());
         emit askForResetPosition();
     }

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -29,8 +29,6 @@ class MyNodeSceneGraphicsItemBase : public MyNodeGraphicsItemBase {
 public:
 
     MyNodeSceneGraphicsItemBase(const QPointF &position, QGraphicsItem *parent = nullptr);
-    
-    void deparent();
 
     void moveChildItems(const QPointF& movedDistance);
     

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -41,12 +41,12 @@ public:
     void enableAddEdgeMode() override;
 
     void enableSelectEdgeMode() override;
+
+    virtual void moveBy(qreal dx, qreal dy);
     
 signals:
     
-    void askForDeparent();
-    
-    void askForReparent();
+    void askForUpdateParentNode();
     
     void askForResetPosition();
 
@@ -57,12 +57,8 @@ protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
-    
-    void keyPressEvent(QKeyEvent *event) override;
-    
-    void keyReleaseEvent(QKeyEvent *event) override;
-    
-    bool _reparent;
+
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 };
 
 class MyClassicNodeSceneGraphicsItemBase : public MyNodeSceneGraphicsItemBase {
@@ -82,7 +78,7 @@ public:
 
     void setFocused(const bool& isFocused) override;
 
-    void moveBy(qreal dx, qreal dy);
+    void moveBy(qreal dx, qreal dy) override;
 
     void adjustOriginalPosition();
 


### PR DESCRIPTION
the whole process of setting a node parent is updated

- there is no need to press 'control' button to set/unset the parent node of a node

- it is possbile to keep the parent node dimensions adjusted to the dimensions of the node it cotains by pressing 'control' button while dragging and dropping the child nodes

- it is possbile to set the parent of a group of node all at once