### PR TITLE
Fix the problem with copying, cutting, and pasting edges and centroid nodes

### DIFF
--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -66,20 +66,6 @@ void MyEdgeBase::setStyle(MyNetworkElementStyleBase* style) {
     setArrowHead();
 }
 
-const bool MyEdgeBase::isCopyable() {
-    if (isSelected() && sourceNode()->isCopyable() && targetNode()->isCopyable())
-        return true;
-
-    return false;
-}
-
-const bool MyEdgeBase::isCuttable() {
-    if (isSelected() && sourceNode()->isCopyable() && targetNode()->isCopyable())
-        return true;
-
-    return false;
-}
-
 void MyEdgeBase::setSelected(const bool& selected) {
     if (selected != isSelected()) {
         MyNetworkElementBase::setSelected(selected);
@@ -263,6 +249,20 @@ MyEdgeBase::EDGE_TYPE MyClassicEdge::edgeType() {
     return CLASSIC_EDGE;
 }
 
+const bool MyClassicEdge::isCopyable() {
+    if (isSelected() && sourceNode()->isCopyable() && targetNode()->isCopyable())
+        return true;
+
+    return false;
+}
+
+const bool MyClassicEdge::isCuttable() {
+    if (isSelected() && sourceNode()->isCopyable() && targetNode()->isCopyable())
+        return true;
+
+    return false;
+}
+
 // MyConnectedToCentroidNodeEdgeBase
 
 MyConnectedToCentroidNodeEdgeBase::MyConnectedToCentroidNodeEdgeBase(const QString& name) : MyEdgeBase(name) {
@@ -288,6 +288,21 @@ MyEdgeBase::EDGE_TYPE MyConnectedToSourceCentroidNodeEdge::edgeType() {
     return CONNECTED_TO_SOURCE_CENTROID_NODE_EDGE;
 }
 
+const bool MyConnectedToSourceCentroidNodeEdge::isCopyable() {
+    if (isSelected() && targetNode()->isCopyable())
+        return true;
+
+    return false;
+}
+
+const bool MyConnectedToSourceCentroidNodeEdge::isCuttable() {
+    if (isSelected() && targetNode()->isCopyable())
+        return true;
+
+    return false;
+}
+
+
 const QPointF MyConnectedToSourceCentroidNodeEdge::nonCentroidNodePosition() {
     return ((MyNodeBase*)targetNode())->getExtents().center();
 }
@@ -307,6 +322,20 @@ MyConnectedToTargetCentroidNodeEdge::MyConnectedToTargetCentroidNodeEdge(const Q
 
 MyEdgeBase::EDGE_TYPE MyConnectedToTargetCentroidNodeEdge::edgeType() {
     return CONNECTED_TO_TARGET_CENTROID_NODE_EDGE;
+}
+
+const bool MyConnectedToTargetCentroidNodeEdge::isCopyable() {
+    if (isSelected() && sourceNode()->isCopyable())
+        return true;
+
+    return false;
+}
+
+const bool MyConnectedToTargetCentroidNodeEdge::isCuttable() {
+    if (isSelected() && sourceNode()->isCopyable())
+        return true;
+
+    return false;
 }
 
 const QPointF MyConnectedToTargetCentroidNodeEdge::nonCentroidNodePosition() {

--- a/src/negui_edge.h
+++ b/src/negui_edge.h
@@ -36,10 +36,6 @@ public:
     
     void setStyle(MyNetworkElementStyleBase* style) override;
 
-    const bool isCopyable() override;
-
-    const bool isCuttable() override;
-
     void setSelectedWithColor(const bool& selected) override;
     
     MyNetworkElementBase* arrowHead();
@@ -112,6 +108,10 @@ public:
     MyClassicEdge(const QString& name, MyNetworkElementBase* sourceNode, MyNetworkElementBase* targetNode);
 
     EDGE_TYPE edgeType() override;
+
+    const bool isCopyable() override;
+
+    const bool isCuttable() override;
 };
 
 class MyConnectedToCentroidNodeEdgeBase : public MyEdgeBase {
@@ -141,6 +141,10 @@ public:
 
     EDGE_TYPE edgeType() override;
 
+    const bool isCopyable() override;
+
+    const bool isCuttable() override;
+
     const QPointF nonCentroidNodePosition() override;
 
     MyNetworkElementBase* nonCentroidNodeParent() override;
@@ -154,6 +158,10 @@ public:
     MyConnectedToTargetCentroidNodeEdge(const QString& name, MyNetworkElementBase* sourceNode, MyNetworkElementBase* targetNode);
 
     EDGE_TYPE edgeType() override;
+
+    const bool isCopyable() override;
+
+    const bool isCuttable() override;
 
     const QPointF nonCentroidNodePosition() override;
 

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -573,6 +573,11 @@ const bool MyInteractor::areAnyElementsSelected() {
 
 void MyInteractor::copySelectedNetworkElements() {
     resetCopiedNetworkElements();
+    for (MyNetworkElementBase* selectedElement : selectedNodes() + selectedEdges()) {
+        if (!selectedElement->isCopyable())
+            return;
+    }
+
     for (MyNetworkElementBase* selectedNode : selectedNodes())
         _copiedNetworkElements.push_back(selectedNode);
     for (MyNetworkElementBase* selectedEdge : selectedEdges())
@@ -583,10 +588,12 @@ void MyInteractor::copySelectedNetworkElements() {
 
 void MyInteractor::cutSelectedNetworkElements() {
     copySelectedNetworkElements();
-    for (MyNetworkElementBase* selectedNode : selectedNodes())
-        removeNode(selectedNode);
-    for (MyNetworkElementBase* selectedEdge : selectedEdges())
-        removeEdge(selectedEdge);
+    if (copiedNetworkElements().size()) {
+        for (MyNetworkElementBase* selectedEdge : selectedEdges())
+            removeEdge(selectedEdge);
+        for (MyNetworkElementBase* selectedNode : selectedNodes())
+            removeNode(selectedNode);
+    }
 }
 
 void MyInteractor::pasteCopiedNetworkElements() {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -503,7 +503,7 @@ const bool MyCentroidNode::isCopyable() {
     if (!isSelected())
         return false;
     for (MyNetworkElementBase* edge : edges()) {
-        if (!edge->isSelected())
+        if (!edge->isCopyable())
             return false;
     }
 


### PR DESCRIPTION
- centroid nodes are now copyable only if all their connected edges are copyable (not just being selected)
    
- edges are now copyable only if all their connected nodes are copyable, which depends on the edge type
