### PR TITLE
Network manager is extracted from the interactor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(source_files
 		negui_plugin_item_builder.cpp
 		negui_plugin_manager.cpp
 		negui_network_manager.cpp
+		negui_default_network_element_style_manager.cpp
 		negui_network_element_base.cpp
 		negui_node.cpp
 		negui_edge.cpp
@@ -108,6 +109,7 @@ set(header_files
 		negui_plugin_item_builder.h
 		negui_plugin_manager.h
 		negui_network_manager.h
+		negui_default_network_element_style_manager.h
 		negui_network_element_base.h
 		negui_node.h
 		negui_edge.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ set(source_files
 		negui_customized_feature_menu_widgets.cpp
 		negui_customized_menu_button_widgets.cpp
 		negui_customized_interactor_widgets.cpp
+		negui_menu_button_manager.cpp
 		negui_menu_button_builder.cpp
 		negui_decorate_menu_buttons.cpp
 		negui_mode_menu.cpp
@@ -168,6 +169,7 @@ set(header_files
         negui_customized_feature_menu_widgets.h
 		negui_customized_menu_button_widgets.h
 		negui_customized_interactor_widgets.h
+		negui_menu_button_manager.h
 		negui_menu_button_builder.h
 		negui_decorate_menu_buttons.h
 		negui_mode_menu.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(source_files
 		negui_plugin_item_base.cpp
 		negui_plugin_item_builder.cpp
 		negui_plugin_manager.cpp
+		negui_network_manager.cpp
 		negui_network_element_base.cpp
 		negui_node.cpp
 		negui_edge.cpp
@@ -105,6 +106,7 @@ set(header_files
 		negui_plugin_item_base.h
 		negui_plugin_item_builder.h
 		negui_plugin_manager.h
+		negui_network_manager.h
 		negui_network_element_base.h
 		negui_node.h
 		negui_edge.h

--- a/src/negui_context_menu.cpp
+++ b/src/negui_context_menu.cpp
@@ -61,7 +61,7 @@ void MyGraphicsSceneContextMenu::initializeActionsStatus() {
 // MyGraphicsItemContextMenuBase
 
 MyGraphicsItemContextMenuBase::MyGraphicsItemContextMenuBase(QWidget *parent) : MyContextMenuBase(parent) {
-    connect(addAction("Features"), SIGNAL(triggered()), this, SIGNAL(askForCreateFeatureMenu()));
+    connect(addAction("Features"), SIGNAL(triggered()), this, SIGNAL(askForDisplayFeatureMenu()));
     addSeparator();
 }
 

--- a/src/negui_context_menu.h
+++ b/src/negui_context_menu.h
@@ -26,15 +26,15 @@ public:
 
 signals:
 
-    const bool askForWhetherSelectedElementsAreCopyable();
+    bool askForWhetherSelectedElementsAreCopyable();
 
-    const bool askForWhetherSelectedElementsAreCuttable();
+    bool askForWhetherSelectedElementsAreCuttable();
 
-    const bool askForWhetherAnyElementsAreAlignable();
+    bool askForWhetherAnyElementsAreAlignable();
 
-    const bool askForWhetherAnyElementsAreCopied();
+    bool askForWhetherAnyElementsAreCopied();
 
-    const bool askForWhetherAnyElementsAreSelected();
+    bool askForWhetherAnyElementsAreSelected();
 
     void askForCopySelectedNetworkElements();
 

--- a/src/negui_context_menu.h
+++ b/src/negui_context_menu.h
@@ -62,7 +62,7 @@ signals:
 
     const bool askForWhetherElementStyleIsCopied();
 
-    void askForCreateFeatureMenu();
+    void askForDisplayFeatureMenu();
 
     void askForCopyNetworkElement();
 

--- a/src/negui_default_network_element_style_manager.cpp
+++ b/src/negui_default_network_element_style_manager.cpp
@@ -1,0 +1,27 @@
+#include "negui_default_network_element_style_manager.h"
+#include "negui_node_style_builder.h"
+#include "negui_edge_style_builder.h"
+
+MyDefaultNetworkElementStyleManager::MyDefaultNetworkElementStyleManager() {
+
+}
+
+MyPluginItemBase* MyDefaultNetworkElementStyleManager::createDefaultNodeStyle(QList<MyPluginItemBase*> plugins) {
+    if (!getPluginsOfType(plugins, "nodestyle").size()) {
+        QJsonObject styleObject;
+        styleObject["name"] = "Default";
+        return createNodeStyle(styleObject);
+    }
+
+    return NULL;
+}
+
+MyPluginItemBase* MyDefaultNetworkElementStyleManager::createDefaultEdgeStyle(QList<MyPluginItemBase*> plugins) {
+    if (!getPluginsOfType(plugins, "edgestyle").size()) {
+        QJsonObject styleObject;
+        styleObject["name"] = "Default";
+        return createEdgeStyle(styleObject);
+    }
+
+    return NULL;
+}

--- a/src/negui_default_network_element_style_manager.h
+++ b/src/negui_default_network_element_style_manager.h
@@ -1,0 +1,20 @@
+#ifndef __NEGUI_DEFAULT_NETWORK_ELEMENT_STYLE_MANAGER_H
+#define __NEGUI_DEFAULT_NETWORK_ELEMENT_STYLE_MANAGER_H
+
+#include <QObject>
+
+#include "negui_plugin_item_base.h"
+
+class MyDefaultNetworkElementStyleManager : public QObject {
+    Q_OBJECT
+
+public:
+
+    MyDefaultNetworkElementStyleManager();
+
+    MyPluginItemBase* createDefaultNodeStyle(QList<MyPluginItemBase*> plugins);
+
+    MyPluginItemBase* createDefaultEdgeStyle(QList<MyPluginItemBase*> plugins);
+};
+
+#endif

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -96,8 +96,7 @@ void MyEdgeBase::setArrowHead() {
 
     if (((MyEdgeStyleBase*)style())->arrowHeadStyle() && ((MyEdgeStyleBase*)style())->arrowHeadStyle()->shapeStyles().size()) {
         _arrowHead = createArrowHead(name() + "_ArrowHead", ((MyEdgeStyleBase*)style())->arrowHeadStyle(), this);
-        connect(_arrowHead, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
-        connect(_arrowHead, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
+        connect(_arrowHead, SIGNAL(askForDisplayFeatureMenu(MyNetworkElementBase*)), this, SIGNAL(askForDisplayFeatureMenu(MyNetworkElementBase*)));
         _isSetArrowHead = true;
     }
 }

--- a/src/negui_edge_style.cpp
+++ b/src/negui_edge_style.cpp
@@ -115,8 +115,7 @@ void MyEdgeStyleBase::read(const QJsonObject &json) {
     _connectableSourceNodeTitle = "";
     if (json.contains("connectable-source-node-title") && json["connectable-source-node-title"].isString())
         _connectableSourceNodeTitle = json["connectable-source-node-title"].toString();
-    
-    _connectableSourceNodeCategories.clear();
+
     if (json.contains("connectable-source-node-categories") && json["connectable-source-node-categories"].isArray()) {
         QJsonArray connectableSourceNodeCategoriesArray = json["connectable-source-node-categories"].toArray();
         for (int connectableSourceNodeCategoryIndex = 0; connectableSourceNodeCategoryIndex < connectableSourceNodeCategoriesArray.size(); ++connectableSourceNodeCategoryIndex) {
@@ -128,9 +127,9 @@ void MyEdgeStyleBase::read(const QJsonObject &json) {
     _connectableTargetNodeTitle = "";
     if (json.contains("connectable-target-node-title") && json["connectable-target-node-title"].isString())
         _connectableTargetNodeTitle = json["connectable-target-node-title"].toString();
-    
-    _connectableTargetNodeCategories.clear();
+
     if (json.contains("connectable-target-node-categories") && json["connectable-target-node-categories"].isArray()) {
+        _connectableTargetNodeCategories.clear();
         QJsonArray connectableTargetNodeCategoriesArray = json["connectable-target-node-categories"].toArray();
         for (int connectableTargetNodeCategoryIndex = 0; connectableTargetNodeCategoryIndex < connectableTargetNodeCategoriesArray.size(); ++connectableTargetNodeCategoryIndex) {
             if (connectableTargetNodeCategoriesArray[connectableTargetNodeCategoryIndex].isString())

--- a/src/negui_graphics_scene.h
+++ b/src/negui_graphics_scene.h
@@ -32,11 +32,11 @@ signals:
     void escapeKeyIsPressed();
     void askForEnableNormalMode();
     void askForSelectAll();
-    const bool askForWhetherSelectedElementsAreCopyable();
-    const bool askForWhetherSelectedElementsAreCuttable();
-    const bool askForWhetherAnyElementsAreAlignable();
-    const bool askForWhetherAnyElementsAreCopied();
-    const bool askForWhetherAnyElementsAreSelected();
+    bool askForWhetherSelectedElementsAreCopyable();
+    bool askForWhetherSelectedElementsAreCuttable();
+    bool askForWhetherAnyElementsAreAlignable();
+    bool askForWhetherAnyElementsAreCopied();
+    bool askForWhetherAnyElementsAreSelected();
     void askForCopySelectedNetworkElements();
     void askForCutSelectedNetworkElements();
     void askForPasteCopiedNetworkElements(const QPointF&);

--- a/src/negui_graphics_view.cpp
+++ b/src/negui_graphics_view.cpp
@@ -167,16 +167,6 @@ void MyGraphicsView::mouseReleaseEvent(QMouseEvent *event) {
     _panMode = false;
 }
 
-void MyGraphicsView::keyPressEvent(QKeyEvent *event) {
-    QGraphicsView::keyPressEvent(event);
-    if (!event->isAccepted()) {
-        if (event->key() == Qt::Key_Return) {
-            emit enterKeyIsPressed();
-            event->accept();
-        }
-    }
-}
-
 void MyGraphicsView::leaveEvent(QEvent *event) {
     emit mouseLeft();
     QGraphicsView::leaveEvent(event);

--- a/src/negui_graphics_view.h
+++ b/src/negui_graphics_view.h
@@ -26,7 +26,6 @@ public:
     
 signals:
 
-    void enterKeyIsPressed();
     void askForDisplayContextMenu(const QPointF& position);
     void mouseLeft();
     void scaleChanged(const qreal);
@@ -51,7 +50,6 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
-    void keyPressEvent(QKeyEvent *event) override;
     void leaveEvent(QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
 

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -4,7 +4,6 @@
 #include "negui_plugin_manager.h"
 #include "negui_menu_button_manager.h"
 #include "negui_customized_interactor_widgets.h"
-#include "negui_multi_network_element_feature_menu.h"
 
 #include <QCoreApplication>
 #include <QFileDialog>
@@ -121,7 +120,8 @@ void MyInteractor::setNetworkManager() {
     connect(_networkManager, SIGNAL(askForIconsDirectoryPath()), this, SLOT(iconsDirectoryPath()));
     connect(_networkManager, SIGNAL(pasteElementsStatusChanged(const bool&)), this, SIGNAL(pasteElementsStatusChanged(const bool&)));
     connect(_networkManager, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
-    connect(_networkManager, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SLOT(displayFeatureMenu(QWidget*)));
+    connect(_networkManager, SIGNAL(askForDisplayFeatureMenu()), this, SIGNAL(askForDisplayFeatureMenu()));
+    connect(_networkManager, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
     connect(_networkManager, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
     connect(_networkManager, SIGNAL(askForSetToolTip(const QString&)), this, SIGNAL(askForSetToolTip(const QString&)));
     connect(_networkManager, SIGNAL(askForSetNetworkBackgroundColor(const QString&)), this, SIGNAL(askForSetNetworkBackgroundColor(const QString&)));
@@ -304,22 +304,6 @@ void MyInteractor::alignSelectedNetworkElements(const QString& alignType) {
     ((MyNetworkManager*)_networkManager)->alignSelectedNetworkElements(alignType);
 }
 
-const QList<MyNetworkElementBase*> MyInteractor::getSelectedElements() {
-    return ((MyNetworkManager*)_networkManager)->getSelectedElements();
-}
-
-MyNetworkElementBase* MyInteractor::getOneSingleSelectedElement() {
-    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
-}
-
-MyNetworkElementBase* MyInteractor::getOneSingleSelectedNode() {
-    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
-}
-
-MyNetworkElementBase* MyInteractor::getOneSingleSelectedEdge() {
-    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
-}
-
 void MyInteractor::setSceneMode(const SceneMode& sceneMode) {
     MySceneModeElementBase::setSceneMode(sceneMode);
     emit modeIsSet(getSceneModeAsString());
@@ -377,34 +361,12 @@ void MyInteractor::enableSelectEdgeMode(const QString& edgeCategory) {
 }
 
 void MyInteractor::displayFeatureMenu() {
-    if (askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()) {
-        if (getOneSingleSelectedNode())
-            getOneSingleSelectedNode()->createFeatureMenu();
-        else if (getOneSingleSelectedEdge())
-            getOneSingleSelectedEdge()->createFeatureMenu();
-        else if (getSelectedElements().size()) {
-            QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), iconsDirectoryPath());
-            connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
-            askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
-        }
-        else
-            askForDisplayFeatureMenu();
-    }
+    if (askForCurrentlyBeingDisplayedNetworkElementFeatureMenu())
+        ((MyNetworkManager*)_networkManager)->displayFeatureMenu();
 }
 
 void MyInteractor::displayFeatureMenu(QWidget* featureMenu) {
-    QString elementName = featureMenu->objectName();
-    if (((MyNetworkManager*)_networkManager)->canDisplaySingleElementFeatureMenu()) {
-        emit askForDisplayFeatureMenu(featureMenu);
-        emit singleNetworkElementFeatureMenuIsDisplayed(elementName);
-    }
-    else {
-        featureMenu->deleteLater();
-        QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), iconsDirectoryPath());
-        connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
-        emit askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
-        emit multiNetworkElementFeatureMenuIsDisplayed(elementName);
-    }
+    ((MyNetworkManager*)_networkManager)->displayFeatureMenu(featureMenu);
 }
 
 void MyInteractor::displaySelectionArea(const QPointF& position) {
@@ -413,7 +375,6 @@ void MyInteractor::displaySelectionArea(const QPointF& position) {
 
 void MyInteractor::clearSelectionArea() {
     ((MyNetworkManager*)_networkManager)->clearSelectionArea();
-    displayFeatureMenu();
 }
 
 void MyInteractor::readFromFile(const QString& importToolName) {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -53,7 +53,7 @@ void MyInteractor::setPluginManager() {
     connect((MyPluginManager*)_pluginManager, &MyPluginManager::askForApplicationDirectoryPath, this, [this] () { return applicationDirectoryPath(); } );
     connect((MyPluginManager*)_pluginManager, &MyPluginManager::askForWorkingDirectoryPath, this, [this] () { return ((MyFileManager*)fileManager())->workingDirectoryPath(); });
     connect((MyPluginManager*)_pluginManager, &MyPluginManager::askForCurrentBaseFileName, this, [this] () { return ((MyFileManager*)fileManager())->currentBaseFileName(); });
-    connect((MyPluginManager*)_pluginManager, &MyPluginManager::askForNetworkInfo, this, [this] () { exportNetworkInfo(); });
+    connect((MyPluginManager*)_pluginManager, &MyPluginManager::askForNetworkInfo, this, [this] () { return exportNetworkInfo(); });
     connect((MyPluginManager*)_pluginManager, &MyPluginManager::networkInfoIsReadFromFile, this, [this] (const QJsonObject &json, MyPluginItemBase* importTool, const QString& fileName) {
         createNetwork(json);
         createChangeStageCommand();
@@ -87,11 +87,11 @@ QList<MyPluginItemBase*>& MyInteractor::pluginItems() {
     return ((MyPluginManager*)_pluginManager)->pluginItems();
 }
 
-const QStringList MyInteractor::listOfPluginItemNames(const QString& type) {
+QStringList MyInteractor::listOfPluginItemNames(const QString& type) {
     return ((MyPluginManager*)_pluginManager)->listOfPluginItemNames(type);
 }
 
-const QStringList MyInteractor::listOfPluginItemCategories(const QString& type) {
+QStringList MyInteractor::listOfPluginItemCategories(const QString& type) {
     return ((MyPluginManager*)_pluginManager)->listOfPluginItemCategories(type);
 }
 

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -111,7 +111,8 @@ void MyInteractor::setNetworkManager() {
     connect(_networkManager, SIGNAL(askForWhetherControlModifierIsPressed()), this, SIGNAL(askForWhetherControlModifierIsPressed()));
     connect(_networkManager, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
     connect(_networkManager, SIGNAL(pasteElementsStatusChanged(const bool&)), this, SIGNAL(pasteElementsStatusChanged(const bool&)));
-    connect(_networkManager, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
+    connect(_networkManager, SIGNAL(askForWhetherFeatureMenuCanBeDisplayed()), this, SIGNAL(askForWhetherFeatureMenuCanBeDisplayed()));
+    connect(_networkManager, SIGNAL(askForEnableFeatureMenuDisplay()), this, SIGNAL(askForEnableFeatureMenuDisplay()));
     connect(_networkManager, SIGNAL(askForDisplayNullFeatureMenu()), this, SIGNAL(askForDisplayNullFeatureMenu()));
     connect(_networkManager, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
     connect(_networkManager, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
@@ -124,8 +125,6 @@ void MyInteractor::setNetworkManager() {
     connect((MyNetworkManager*)_networkManager, &MyNetworkManager::askForEnableNormalMode, this, [this] () { enableNormalMode(); });
     connect((MyNetworkManager*)_networkManager, &MyNetworkManager::askForClearUndoStack, this, [this] () { undoStack()->clear(); });
     connect((MyNetworkManager*)_networkManager, &MyNetworkManager::askForIconsDirectoryPath, this, [this] () { return iconsDirectoryPath(); });
-    connect(this, SIGNAL(singleNetworkElementFeatureMenuIsDisplayed(const QString&)), _networkManager, SIGNAL(singleNetworkElementFeatureMenuIsDisplayed(const QString&)));
-    connect(this, SIGNAL(multiNetworkElementFeatureMenuIsDisplayed(const QString&)), _networkManager, SIGNAL(multiNetworkElementFeatureMenuIsDisplayed(const QString&)));
     connect(this, SIGNAL(askForAdjustExtentsOfNodes()), _networkManager, SIGNAL(askForAdjustExtentsOfNodes()));
     connect(this, SIGNAL(askForAdjustConnectedEdgesOfNodes()), _networkManager, SIGNAL(askForAdjustConnectedEdgesOfNodes()));
 }
@@ -355,10 +354,6 @@ void MyInteractor::alignSelectedNetworkElements(const QString& alignType) {
 
 void MyInteractor::updateFeatureMenu() {
     ((MyNetworkManager*)_networkManager)->updateFeatureMenu();
-}
-
-void MyInteractor::displayFeatureMenu(QWidget* featureMenu) {
-    ((MyNetworkManager*)_networkManager)->displayFeatureMenu(featureMenu);
 }
 
 void MyInteractor::displaySelectionArea(const QPointF& position) {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -3,6 +3,7 @@
 #include "negui_file_manager.h"
 #include "negui_plugin_manager.h"
 #include "negui_menu_button_manager.h"
+#include "negui_default_network_element_style_manager.h"
 #include "negui_customized_interactor_widgets.h"
 
 #include <QCoreApplication>
@@ -95,7 +96,8 @@ const QStringList MyInteractor::listOfPluginItemCategories(const QString& type) 
 }
 
 void MyInteractor::addPluginItem(MyPluginItemBase* pluginItem) {
-    ((MyPluginManager*)_pluginManager)->addPluginItem(pluginItem);
+    if (pluginItem)
+        ((MyPluginManager*)_pluginManager)->addPluginItem(pluginItem);
 }
 
 void MyInteractor::setNetworkManager() {
@@ -145,7 +147,6 @@ QObject* MyInteractor::fileManager() {
 
 void MyInteractor::setMenuButtonManager() {
     _menuButtonManager = new MyMenuButtonManager();
-    connect((MyMenuButtonManager*)_menuButtonManager, &MyMenuButtonManager::askForAddPluginItem, this, [this] (MyPluginItemBase* plugin) { addPluginItem(plugin); });
 }
 
 QObject* MyInteractor::menuButtonManager() {
@@ -413,7 +414,15 @@ QList<QAbstractButton*> MyInteractor::getToolbarMenuButtons() {
 }
 
 QList<QAbstractButton*> MyInteractor::getModeMenuButtons() {
+    addDefaultNetworkElementStyles();
     return ((MyMenuButtonManager*)_menuButtonManager)->getModeMenuButtons(this, pluginItems(), iconsDirectoryPath());
+}
+
+void MyInteractor::addDefaultNetworkElementStyles() {
+    MyDefaultNetworkElementStyleManager* defaultNetworkElementStyleManager = new MyDefaultNetworkElementStyleManager();
+    addPluginItem(defaultNetworkElementStyleManager->createDefaultNodeStyle(pluginItems()));
+    addPluginItem(defaultNetworkElementStyleManager->createDefaultEdgeStyle(pluginItems()));
+    defaultNetworkElementStyleManager->deleteLater();
 }
 
 void MyInteractor::createChangeStageCommand() {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -2,11 +2,9 @@
 #include "negui_network_manager.h"
 #include "negui_file_manager.h"
 #include "negui_plugin_manager.h"
+#include "negui_menu_button_manager.h"
 #include "negui_customized_interactor_widgets.h"
-#include "negui_menu_button_builder.h"
 #include "negui_multi_network_element_feature_menu.h"
-#include "negui_node_style_builder.h"
-#include "negui_edge_style_builder.h"
 
 #include <QCoreApplication>
 #include <QFileDialog>
@@ -22,6 +20,7 @@ MyInteractor::MyInteractor(QObject *parent) : QObject(parent) {
     loadPlugins();
     setNetworkManager();
     setFileManager();
+    setMenuButtonManager();
     initializeStageInfo();
 };
 
@@ -150,6 +149,15 @@ void MyInteractor::setFileManager() {
 
 QObject* MyInteractor::fileManager() {
     return _fileManager;
+}
+
+void MyInteractor::setMenuButtonManager() {
+    _menuButtonManager = new MyMenuButtonManager();
+    connect((MyMenuButtonManager*)_menuButtonManager, &MyMenuButtonManager::askForAddPluginItem, this, [this] (MyPluginItemBase* plugin) { addPluginItem(plugin); });
+}
+
+QObject* MyInteractor::menuButtonManager() {
+    return _menuButtonManager;
 }
 
 void MyInteractor::initializeStageInfo() {
@@ -448,29 +456,11 @@ void MyInteractor::autoLayout(MyPluginItemBase* autoLayoutEngine) {
 }
 
 QList<QAbstractButton*> MyInteractor::getToolbarMenuButtons() {
-    return createToolbarMenuButtons(this, undoStack(), pluginItems(), iconsDirectoryPath());
+    return ((MyMenuButtonManager*)_menuButtonManager)->getToolbarMenuButtons(this, undoStack(), pluginItems(), iconsDirectoryPath());
 }
 
 QList<QAbstractButton*> MyInteractor::getModeMenuButtons() {
-    addDefaultNodeStyle();
-    addDefaultEdgeStyle();
-    return createModeMenuButtons(this, pluginItems(), iconsDirectoryPath());
-}
-
-void MyInteractor::addDefaultNodeStyle() {
-    if (!getPluginsOfType(pluginItems(), "nodestyle").size()) {
-        QJsonObject styleObject;
-        styleObject["name"] = "Default";
-        addPluginItem(createNodeStyle(styleObject));
-    }
-}
-
-void MyInteractor::addDefaultEdgeStyle() {
-    if (!getPluginsOfType(pluginItems(), "edgestyle").size()) {
-        QJsonObject styleObject;
-        styleObject["name"] = "Default";
-        addPluginItem(createEdgeStyle(styleObject));
-    }
+    return ((MyMenuButtonManager*)_menuButtonManager)->getModeMenuButtons(this, pluginItems(), iconsDirectoryPath());
 }
 
 void MyInteractor::createChangeStageCommand() {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -113,6 +113,7 @@ void MyInteractor::setNetworkManager() {
     connect(_networkManager, SIGNAL(pasteElementsStatusChanged(const bool&)), this, SIGNAL(pasteElementsStatusChanged(const bool&)));
     connect(_networkManager, SIGNAL(askForWhetherFeatureMenuCanBeDisplayed()), this, SIGNAL(askForWhetherFeatureMenuCanBeDisplayed()));
     connect(_networkManager, SIGNAL(askForEnableFeatureMenuDisplay()), this, SIGNAL(askForEnableFeatureMenuDisplay()));
+    connect(_networkManager, SIGNAL(askForCurrentlyBeingDisplayedFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedFeatureMenu()));
     connect(_networkManager, SIGNAL(askForDisplayNullFeatureMenu()), this, SIGNAL(askForDisplayNullFeatureMenu()));
     connect(_networkManager, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
     connect(_networkManager, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -112,7 +112,7 @@ void MyInteractor::setNetworkManager() {
     connect(_networkManager, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
     connect(_networkManager, SIGNAL(pasteElementsStatusChanged(const bool&)), this, SIGNAL(pasteElementsStatusChanged(const bool&)));
     connect(_networkManager, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
-    connect(_networkManager, SIGNAL(askForDisplayFeatureMenu()), this, SIGNAL(askForDisplayFeatureMenu()));
+    connect(_networkManager, SIGNAL(askForDisplayNullFeatureMenu()), this, SIGNAL(askForDisplayNullFeatureMenu()));
     connect(_networkManager, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
     connect(_networkManager, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
     connect(_networkManager, SIGNAL(askForSetToolTip(const QString&)), this, SIGNAL(askForSetToolTip(const QString&)));
@@ -353,8 +353,8 @@ void MyInteractor::alignSelectedNetworkElements(const QString& alignType) {
     ((MyNetworkManager*)_networkManager)->alignSelectedNetworkElements(alignType);
 }
 
-void MyInteractor::displayFeatureMenu() {
-    ((MyNetworkManager*)_networkManager)->displayFeatureMenu();
+void MyInteractor::updateFeatureMenu() {
+    ((MyNetworkManager*)_networkManager)->updateFeatureMenu();
 }
 
 void MyInteractor::displayFeatureMenu(QWidget* featureMenu) {
@@ -367,7 +367,6 @@ void MyInteractor::displaySelectionArea(const QPointF& position) {
 
 void MyInteractor::clearSelectionArea() {
     ((MyNetworkManager*)_networkManager)->clearSelectionArea();
-    displayFeatureMenu();
 }
 
 void MyInteractor::readFromFile(const QString& importToolName) {

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -2,17 +2,11 @@
 #include "negui_network_manager.h"
 #include "negui_file_manager.h"
 #include "negui_plugin_manager.h"
-#include "negui_node.h"
-#include "negui_edge.h"
-#include "negui_node_builder.h"
-#include "negui_edge_builder.h"
-#include "negui_new_edge_builder.h"
-#include "negui_copied_network_elements_paster.h"
-#include "negui_node_style_builder.h"
-#include "negui_edge_style_builder.h"
 #include "negui_customized_interactor_widgets.h"
 #include "negui_menu_button_builder.h"
 #include "negui_multi_network_element_feature_menu.h"
+#include "negui_node_style_builder.h"
+#include "negui_edge_style_builder.h"
 
 #include <QCoreApplication>
 #include <QFileDialog>
@@ -22,25 +16,26 @@
 // MyInteractor
 
 MyInteractor::MyInteractor(QObject *parent) : QObject(parent) {
-    // undo stack
-    _undoStack = new MyUndoStack(this);
-
-    _applicationDirectory = QDir(QCoreApplication::applicationDirPath());
-
-    // plugins
+    setUndoStack();
+    setApplicationDirectory();
     setPluginManager();
     loadPlugins();
-
-    // network manager
     setNetworkManager();
-
-    // file manager
     setFileManager();
-
-    // network
-    resetNetwork();
-    _stageInfo = getNetworkElementsAndColorInfo();
+    initializeStageInfo();
 };
+
+void MyInteractor::setUndoStack() {
+    _undoStack = new MyUndoStack(this);
+}
+
+QUndoStack* MyInteractor::undoStack() {
+    return _undoStack;
+}
+
+void MyInteractor::setApplicationDirectory() {
+    _applicationDirectory = QDir(QCoreApplication::applicationDirPath());
+}
 
 QDir MyInteractor::applicationDirectory() {
     return _applicationDirectory;
@@ -60,457 +55,6 @@ QDir MyInteractor::iconsDirectory() {
 
 const QString MyInteractor::iconsDirectoryPath() {
     return iconsDirectory().path();
-}
-
-QUndoStack* MyInteractor::undoStack() {
-    return _undoStack;
-}
-
-QObject* MyInteractor::networkManager() {
-    return _networkManager;
-}
-
-QObject* MyInteractor::fileManager() {
-    return _fileManager;
-}
-
-void MyInteractor::createChangeStageCommand() {
-    QJsonObject currentStageInfo = getNetworkElementsAndColorInfo();
-    if (undoStack()->count() > undoStack()->index()) {
-        const QUndoCommand* indexCommand = undoStack()->command(undoStack()->index());
-        _stageInfo = ((MyChangeStageCommand*)indexCommand)->previousStageInfo();
-    }
-    if (currentStageInfo != _stageInfo) {
-        ((MyFileManager*)fileManager())->setCurrentNetworkUnsaved(true);
-        MyChangeStageCommand* changeStageCommand = new MyChangeStageCommand(_stageInfo, currentStageInfo);
-        ((MyUndoStack*)undoStack())->addCommand(changeStageCommand);
-        connect(changeStageCommand, SIGNAL(askForCreateNetwork(const QJsonObject&)), this, SLOT(createNetwork(const QJsonObject&)));
-        _stageInfo = currentStageInfo;
-    }
-}
-
-void MyInteractor::createNetwork(const QJsonObject& json) {
-    ((MyNetworkManager*)_networkManager)->createNetwork(json);
-}
-
-void MyInteractor::setNewNetworkCanvas() {
-    if (((MyFileManager*)fileManager())->canSaveCurrentNetwork())
-        saveCurrentNetwork();
-    askForRemoveFeatureMenu();
-    ((MyNetworkManager*)_networkManager)->resetNetworkCanvas();
-    ((MyFileManager*)fileManager())->reset();
-}
-
-void MyInteractor::resetNetworkCanvas() {
-    ((MyNetworkManager*)_networkManager)->resetNetworkCanvas();
-}
-
-void MyInteractor::resetCanvas() {
-    ((MyNetworkManager*)_networkManager)->resetCanvas();
-}
-
-void MyInteractor::resetNetwork() {
-    ((MyNetworkManager*)_networkManager)->resetNetwork();
-}
-
-void MyInteractor::setBackground(const QJsonObject &json) {
-    ((MyNetworkManager*)_networkManager)->setBackground(json);
-}
-
-QList<MyNetworkElementBase*>& MyInteractor::nodes() {
-    return ((MyNetworkManager*)_networkManager)->nodes();
-}
-
-void MyInteractor::addNodes(const QJsonObject &json) {
-    ((MyNetworkManager*)_networkManager)->addNodes(json);
-}
-
-void MyInteractor::addNode(const QJsonObject &json) {
-    ((MyNetworkManager*)_networkManager)->addNode(json);
-}
-
-void MyInteractor::addNode(MyNetworkElementBase* n) {
-    ((MyNetworkManager*)_networkManager)->addNode(n);
-}
-
-void MyInteractor::addNewNode(const QPointF& position) {
-    ((MyNetworkManager*)_networkManager)->addNewNode(position);
-}
-
-void MyInteractor::removeNode(MyNetworkElementBase* n) {
-    ((MyNetworkManager*)_networkManager)->removeNode(n);
-}
-
-void MyInteractor::clearNodesInfo() {
-    ((MyNetworkManager*)_networkManager)->clearNodesInfo();
-}
-
-void MyInteractor::setNodeStyle(MyNetworkElementStyleBase* style) {
-    ((MyNetworkManager*)_networkManager)->setNodeStyle(style);
-}
-
-MyNetworkElementStyleBase* MyInteractor::nodeStyle() {
-    return ((MyNetworkManager*)_networkManager)->nodeStyle();
-}
-
-void MyInteractor::setCopiedNode(MyNetworkElementBase* node) {
-    ((MyNetworkManager*)_networkManager)->setCopiedNode(node);
-}
-
-void MyInteractor::setCutNode(MyNetworkElementBase* node) {
-    ((MyNetworkManager*)_networkManager)->setCutNode(node);
-}
-
-const bool MyInteractor::isSetCopiedNodeStyle() {
-    return ((MyNetworkManager*)_networkManager)->isSetCopiedNodeStyle();
-}
-
-void MyInteractor::setCopiedNodeStyle(MyNetworkElementStyleBase* style) {
-    ((MyNetworkManager*)_networkManager)->setCopiedNodeStyle(style);
-}
-
-MyNetworkElementStyleBase* MyInteractor::copiedNodeStyle() {
-    return ((MyNetworkManager*)_networkManager)->copiedNodeStyle();
-}
-
-void MyInteractor::pasteCopiedNodeStyle(MyNetworkElementBase* element) {
-    ((MyNetworkManager*)_networkManager)->pasteCopiedNodeStyle(element);
-}
-
-QList<MyNetworkElementBase*>& MyInteractor::edges() {
-    return ((MyNetworkManager*)_networkManager)->edges();
-}
-
-void MyInteractor::addEdges(const QJsonObject &json) {
-    ((MyNetworkManager*)_networkManager)->addEdges(json);
-}
-
-void MyInteractor::addEdge(const QJsonObject &json) {
-    ((MyNetworkManager*)_networkManager)->addEdge(json);
-}
-
-void MyInteractor::addEdge(MyNetworkElementBase* e) {
-    ((MyNetworkManager*)_networkManager)->addEdge(e);
-}
-
-void MyInteractor::addNewEdge(MyNetworkElementBase* element) {
-    ((MyNetworkManager*)_networkManager)->addNewEdge(element);
-}
-
-void MyInteractor::removeEdge(MyNetworkElementBase* e) {
-    ((MyNetworkManager*)_networkManager)->removeEdge(e);
-}
-
-void MyInteractor::clearEdgesInfo() {
-    ((MyNetworkManager*)_networkManager)->clearEdgesInfo();
-}
-
-void MyInteractor::setEdgeStyle(MyNetworkElementStyleBase* style) {
-    ((MyNetworkManager*)_networkManager)->setEdgeStyle(style);
-}
-
-MyNetworkElementStyleBase* MyInteractor::edgeStyle() {
-    return ((MyNetworkManager*)_networkManager)->edgeStyle();
-}
-
-const bool MyInteractor::isSetCopiedEdgeStyle() {
-    return ((MyNetworkManager*)_networkManager)->isSetCopiedEdgeStyle();
-}
-
-void MyInteractor::setCopiedEdgeStyle(MyNetworkElementStyleBase* style) {
-    ((MyNetworkManager*)_networkManager)->setCopiedEdgeStyle(style);
-}
-
-MyNetworkElementStyleBase* MyInteractor::copiedEdgeStyle() {
-    return ((MyNetworkManager*)_networkManager)->copiedEdgeStyle();
-}
-
-void MyInteractor::pasteCopiedEdgeStyle(MyNetworkElementBase* element) {
-    ((MyNetworkManager*)_networkManager)->pasteCopiedEdgeStyle(element);
-}
-
-const bool MyInteractor::areSelectedElementsCopyable() {
-    return ((MyNetworkManager*)_networkManager)->areSelectedElementsCopyable();
-}
-
-const bool MyInteractor::areSelectedElementsCuttable() {
-    return ((MyNetworkManager*)_networkManager)->areSelectedElementsCuttable();
-}
-
-const bool MyInteractor::areSelectedElementsAlignable() {
-    return ((MyNetworkManager*)_networkManager)->areSelectedElementsAlignable();
-}
-
-const bool MyInteractor::areAnyElementsCopied() {
-    return ((MyNetworkManager*)_networkManager)->areAnyElementsCopied();
-}
-
-const bool MyInteractor::areAnyElementsSelected() {
-    return ((MyNetworkManager*)_networkManager)->areAnyElementsSelected();
-}
-
-void MyInteractor::copySelectedNetworkElements() {
-    ((MyNetworkManager*)_networkManager)->copySelectedNetworkElements();
-}
-
-void MyInteractor::cutSelectedNetworkElements() {
-    ((MyNetworkManager*)_networkManager)->cutSelectedNetworkElements();
-}
-
-void MyInteractor::pasteCopiedNetworkElements() {
-    ((MyNetworkManager*)_networkManager)->pasteCopiedNetworkElements();
-}
-
-void MyInteractor::pasteCopiedNetworkElements(const QPointF& position) {
-    ((MyNetworkManager*)_networkManager)->pasteCopiedNetworkElements(position);
-}
-
-QList<MyNetworkElementBase*> MyInteractor::copiedNetworkElements() {
-    return ((MyNetworkManager*)_networkManager)->copiedNetworkElements();
-}
-
-void MyInteractor::resetCopiedNetworkElements() {
-    ((MyNetworkManager*)_networkManager)->resetCopiedNetworkElements();
-}
-
-void MyInteractor::moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance) {
-    ((MyNetworkManager*)_networkManager)->moveSelectedNetworkElements(movedNode, movedDistance);
-}
-
-bool MyInteractor::edgeExists(MyNetworkElementBase* n1, MyNetworkElementBase* n2) {
-    return ((MyNetworkManager*)_networkManager)->edgeExists(n1, n2);
-}
-
-QJsonObject MyInteractor::getNetworkElementsAndColorInfo() {
-    return ((MyNetworkManager*)_networkManager)->getNetworkElementsAndColorInfo();
-}
-
-QJsonObject MyInteractor::exportNetworkInfo() {
-    return ((MyNetworkManager*)_networkManager)->exportNetworkInfo();
-}
-
-void MyInteractor::selectElements(const bool& selected) {
-    ((MyNetworkManager*)_networkManager)->selectElements(selected);
-}
-
-void MyInteractor::selectElementsOfCategory(const bool& selected, const QString& category) {
-    ((MyNetworkManager*)_networkManager)->selectElementsOfCategory(selected, category);
-}
-
-void MyInteractor::selectNodes(const bool& selected) {
-    ((MyNetworkManager*)_networkManager)->selectNodes(selected);
-}
-
-void MyInteractor::selectNodesOfCategory(const bool& selected, const QString& category) {
-    ((MyNetworkManager*)_networkManager)->selectNodesOfCategory(selected, category);
-}
-
-void MyInteractor::selectEdges(const bool& selected) {
-    ((MyNetworkManager*)_networkManager)->selectEdges(selected);
-}
-
-void MyInteractor::selectEdgesOfCategory(const bool& selected, const QString& category) {
-    ((MyNetworkManager*)_networkManager)->selectEdgesOfCategory(selected, category);
-}
-
-void MyInteractor::changeElementSelectionsStatus(MyNetworkElementBase* element) {
-    ((MyNetworkManager*)_networkManager)->changeElementSelectionsStatus(element);
-}
-
-void MyInteractor::setElementSelected(const QString& elementName) {
-    ((MyNetworkManager*)_networkManager)->setElementSelected(elementName);
-}
-
-void MyInteractor::deleteNode(MyNetworkElementBase* node) {
-    ((MyNetworkManager*)_networkManager)->deleteNode(node);
-}
-
-void MyInteractor::deleteEdge(MyNetworkElementBase* edge) {
-    ((MyNetworkManager*)_networkManager)->deleteEdge(edge);
-}
-
-void MyInteractor::deleteSelectedNetworkElements() {
-    ((MyNetworkManager*)_networkManager)->deleteSelectedNetworkElements();
-}
-
-void MyInteractor::alignSelectedNetworkElements(const QString& alignType) {
-    ((MyNetworkManager*)_networkManager)->alignSelectedNetworkElements(alignType);
-}
-
-const QList<MyNetworkElementBase*> MyInteractor::getSelectedElements() {
-    return ((MyNetworkManager*)_networkManager)->getSelectedElements();
-}
-
-const QList<MyNetworkElementBase*> MyInteractor::getSelectedNodes() {
-    return ((MyNetworkManager*)_networkManager)->getSelectedNodes();
-}
-
-const QList<MyNetworkElementBase*> MyInteractor::getSelectedEdges() {
-    return ((MyNetworkManager*)_networkManager)->getSelectedEdges();
-}
-
-MyNetworkElementBase* MyInteractor::getOneSingleSelectedElement() {
-    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
-}
-
-MyNetworkElementBase* MyInteractor::getOneSingleSelectedNode() {
-    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
-}
-
-MyNetworkElementBase* MyInteractor::getOneSingleSelectedEdge() {
-    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
-}
-
-void MyInteractor::setSceneMode(const SceneMode& sceneMode) {
-    MySceneModeElementBase::setSceneMode(sceneMode);
-    emit modeIsSet(getSceneModeAsString());
-}
-
-void MyInteractor::enableNormalMode() {
-    MySceneModeElementBase::enableNormalMode();
-    ((MyNetworkManager*)_networkManager)->enableNormalMode();
-
-    emit askForSetToolTip("");
-}
-
-void MyInteractor::enableAddNodeMode(MyPluginItemBase* style) {
-    enableNormalMode();
-    MySceneModeElementBase::enableAddNodeMode();
-    askForRemoveFeatureMenu();
-    ((MyNetworkManager*)_networkManager)->enableAddNodeMode(dynamic_cast<MyNetworkElementStyleBase*>(style));
-    
-    emit askForSetToolTip(((MyNetworkElementStyleBase*)style)->toolTipText());
-    emit addElementModeIsEnabled(style->name());
-}
-
-void MyInteractor::enableAddEdgeMode(MyPluginItemBase* style) {
-    enableNormalMode();
-    MySceneModeElementBase::enableAddEdgeMode();
-    askForRemoveFeatureMenu();
-    ((MyNetworkManager*)_networkManager)->enableAddEdgeMode(dynamic_cast<MyNetworkElementStyleBase*>(style));
-
-    emit askForSetToolTip(((MyNetworkElementStyleBase*)style)->toolTipText());
-    emit addElementModeIsEnabled(style->name());
-}
-
-void MyInteractor::enableSelectMode(const QString& elementCategory) {
-    enableNormalMode();
-    MySceneModeElementBase::enableSelectMode();
-    ((MyNetworkManager*)_networkManager)->enableSelectMode();
-
-    emit askForSetToolTip("Select" + elementCategory);
-}
-
-void MyInteractor::enableSelectNodeMode(const QString& nodeCategory) {
-    enableNormalMode();
-    MySceneModeElementBase::enableSelectNodeMode();
-    ((MyNetworkManager*)_networkManager)->enableSelectNodeMode();
-    
-    emit askForSetToolTip("Select " + nodeCategory + " nodes");
-}
-
-void MyInteractor::enableSelectEdgeMode(const QString& edgeCategory) {
-    enableNormalMode();
-    MySceneModeElementBase::enableSelectEdgeMode();
-    ((MyNetworkManager*)_networkManager)->enableSelectEdgeMode();
-    ((MyNetworkManager*)_networkManager)->enableSelectEdgeMode();
-    for (MyNetworkElementBase *node : qAsConst(nodes()))
-        node->enableSelectEdgeMode();
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
-        edge->enableSelectEdgeMode();
-    
-    emit askForSetToolTip("Select " + edgeCategory + " edges");
-}
-
-void MyInteractor::displayFeatureMenu() {
-    if (askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()) {
-        if (getOneSingleSelectedNode())
-            getOneSingleSelectedNode()->createFeatureMenu();
-        else if (getOneSingleSelectedEdge())
-            getOneSingleSelectedEdge()->createFeatureMenu();
-        else if (getSelectedElements().size()) {
-            QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), iconsDirectoryPath());
-            connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
-            askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
-        }
-        else
-            askForDisplayFeatureMenu();
-    }
-}
-
-void MyInteractor::displayFeatureMenu(QWidget* featureMenu) {
-    QString elementName = featureMenu->objectName();
-    if (((MyNetworkManager*)_networkManager)->canDisplaySingleElementFeatureMenu()) {
-        emit askForDisplayFeatureMenu(featureMenu);
-        emit singleNetworkElementFeatureMenuIsDisplayed(elementName);
-    }
-    else {
-        featureMenu->deleteLater();
-        QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), iconsDirectoryPath());
-        connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
-        emit askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
-        emit multiNetworkElementFeatureMenuIsDisplayed(elementName);
-    }
-}
-
-void MyInteractor::displaySelectionArea(const QPointF& position) {
-    ((MyNetworkManager*)_networkManager)->displaySelectionArea(position);
-}
-
-void MyInteractor::createSelectionAreaGraphicsItem(const QPointF& position) {
-    ((MyNetworkManager*)_networkManager)->createSelectionAreaGraphicsItem(position);
-}
-
-void MyInteractor::selectSelectionAreaCoveredNodes() {
-    ((MyNetworkManager*)_networkManager)->selectSelectionAreaCoveredNodes();
-}
-
-void MyInteractor::selectSelectionAreaCoveredEdges() {
-    ((MyNetworkManager*)_networkManager)->selectSelectionAreaCoveredEdges();
-}
-
-void MyInteractor::clearSelectionArea() {
-    ((MyNetworkManager*)_networkManager)->clearSelectionArea();
-    displayFeatureMenu();
-}
-
-void MyInteractor::readFromFile(const QString& importToolName) {
-    if (((MyFileManager*)fileManager())->canSaveCurrentNetwork())
-        saveCurrentNetwork();
-    ((MyPluginManager*)_pluginManager)->readFromFile(importToolName);
-}
-
-void MyInteractor::readFromFile(MyPluginItemBase* importTool) {
-    if (((MyFileManager*)fileManager())->canSaveCurrentNetwork())
-        saveCurrentNetwork();
-    ((MyPluginManager*)_pluginManager)->readFromFile(importTool);
-}
-
-void MyInteractor::writeDataToFile(const QString& exportToolName) {
-    ((MyPluginManager*)_pluginManager)->writeDataToFile(exportToolName);
-}
-
-void MyInteractor::writeDataToFile(MyPluginItemBase* exportTool) {
-    ((MyPluginManager*)_pluginManager)->writeDataToFile(exportTool);
-}
-
-void MyInteractor::writeFigureToFile(const QString& exportToolName) {
-    ((MyPluginManager*)_pluginManager)->writeFigureToFile(exportToolName);
-}
-
-void MyInteractor::writeFigureToFile(MyPluginItemBase* exportTool) {
-    ((MyPluginManager*)_pluginManager)->writeFigureToFile(exportTool);
-}
-
-void MyInteractor::saveCurrentNetwork() {
-    if (((MyFileManager*)fileManager())->lastSavedFileName().isEmpty())
-        ((MyPluginManager*)_pluginManager)->writeDataToFile(((MyFileManager*)fileManager())->currentExportTool());
-    else
-        ((MyPluginManager*)_pluginManager)->writeDataToFile(((MyFileManager*)fileManager())->currentExportTool(), ((MyFileManager*)fileManager())->currentFileName());
-}
-
-void MyInteractor::autoLayout(MyPluginItemBase* autoLayoutEngine) {
-    ((MyPluginManager*)_pluginManager)->autoLayout(autoLayoutEngine);
 }
 
 void MyInteractor::setPluginManager() {
@@ -593,11 +137,314 @@ void MyInteractor::setNetworkManager() {
     connect(this, SIGNAL(askForAdjustConnectedEdgesOfNodes()), _networkManager, SIGNAL(askForAdjustConnectedEdgesOfNodes()));
 }
 
+QObject* MyInteractor::networkManager() {
+    return _networkManager;
+}
+
 void MyInteractor::setFileManager() {
     _fileManager = new MyFileManager(getPluginsOfType(pluginItems(), "importtool"), getPluginsOfType(pluginItems(), "dataexporttool"));
     connect(_fileManager, SIGNAL(currentFileNameIsUpdated(const QString&)), this, SIGNAL(currentFileNameIsUpdated(const QString&)));
     connect(this, &MyInteractor::askForWorkingDirectoryPath, this, [this] () { return ((MyFileManager*)fileManager())->workingDirectoryPath(); });
     connect(this, &MyInteractor::askForSettingWorkingDirectoryPath, this, [this] (const QString& workingDirectoryPath) { ((MyFileManager*)fileManager())->setWorkingDirectoryPath(QFileInfo(workingDirectoryPath).absolutePath() + "/"); });
+}
+
+QObject* MyInteractor::fileManager() {
+    return _fileManager;
+}
+
+void MyInteractor::initializeStageInfo() {
+    _stageInfo = getNetworkElementsAndColorInfo();
+}
+
+void MyInteractor::createNetwork(const QJsonObject& json) {
+    ((MyNetworkManager*)_networkManager)->createNetwork(json);
+}
+
+void MyInteractor::setNewNetworkCanvas() {
+    if (((MyFileManager*)fileManager())->canSaveCurrentNetwork())
+        saveCurrentNetwork();
+    askForRemoveFeatureMenu();
+    ((MyNetworkManager*)_networkManager)->resetNetworkCanvas();
+    ((MyFileManager*)fileManager())->reset();
+}
+
+void MyInteractor::resetNetworkCanvas() {
+    ((MyNetworkManager*)_networkManager)->resetNetworkCanvas();
+}
+
+void MyInteractor::resetNetwork() {
+    ((MyNetworkManager*)_networkManager)->resetNetwork();
+}
+
+void MyInteractor::resetCanvas() {
+    ((MyNetworkManager*)_networkManager)->resetCanvas();
+}
+
+void MyInteractor::setBackground(const QJsonObject &json) {
+    ((MyNetworkManager*)_networkManager)->setBackground(json);
+}
+
+void MyInteractor::addNodes(const QJsonObject &json) {
+    ((MyNetworkManager*)_networkManager)->addNodes(json);
+}
+
+void MyInteractor::addNode(const QJsonObject &json) {
+    ((MyNetworkManager*)_networkManager)->addNode(json);
+}
+
+void MyInteractor::addNewNode(const QPointF& position) {
+    ((MyNetworkManager*)_networkManager)->addNewNode(position);
+}
+
+void MyInteractor::clearNodesInfo() {
+    ((MyNetworkManager*)_networkManager)->clearNodesInfo();
+}
+
+void MyInteractor::addEdges(const QJsonObject &json) {
+    ((MyNetworkManager*)_networkManager)->addEdges(json);
+}
+
+void MyInteractor::addEdge(const QJsonObject &json) {
+    ((MyNetworkManager*)_networkManager)->addEdge(json);
+}
+
+void MyInteractor::clearEdgesInfo() {
+    ((MyNetworkManager*)_networkManager)->clearEdgesInfo();
+}
+
+const bool MyInteractor::areSelectedElementsCopyable() {
+    return ((MyNetworkManager*)_networkManager)->areSelectedElementsCopyable();
+}
+
+const bool MyInteractor::areSelectedElementsCuttable() {
+    return ((MyNetworkManager*)_networkManager)->areSelectedElementsCuttable();
+}
+
+const bool MyInteractor::areSelectedElementsAlignable() {
+    return ((MyNetworkManager*)_networkManager)->areSelectedElementsAlignable();
+}
+
+const bool MyInteractor::areAnyElementsCopied() {
+    return ((MyNetworkManager*)_networkManager)->areAnyElementsCopied();
+}
+
+const bool MyInteractor::areAnyElementsSelected() {
+    return ((MyNetworkManager*)_networkManager)->areAnyElementsSelected();
+}
+
+void MyInteractor::copySelectedNetworkElements() {
+    ((MyNetworkManager*)_networkManager)->copySelectedNetworkElements();
+}
+
+void MyInteractor::cutSelectedNetworkElements() {
+    ((MyNetworkManager*)_networkManager)->cutSelectedNetworkElements();
+}
+
+void MyInteractor::pasteCopiedNetworkElements() {
+    ((MyNetworkManager*)_networkManager)->pasteCopiedNetworkElements();
+}
+
+void MyInteractor::pasteCopiedNetworkElements(const QPointF& position) {
+    ((MyNetworkManager*)_networkManager)->pasteCopiedNetworkElements(position);
+}
+
+void MyInteractor::resetCopiedNetworkElements() {
+    ((MyNetworkManager*)_networkManager)->resetCopiedNetworkElements();
+}
+
+QJsonObject MyInteractor::getNetworkElementsAndColorInfo() {
+    return ((MyNetworkManager*)_networkManager)->getNetworkElementsAndColorInfo();
+}
+
+QJsonObject MyInteractor::exportNetworkInfo() {
+    return ((MyNetworkManager*)_networkManager)->exportNetworkInfo();
+}
+
+void MyInteractor::selectElements(const bool& selected) {
+    ((MyNetworkManager*)_networkManager)->selectElements(selected);
+}
+
+void MyInteractor::selectElementsOfCategory(const bool& selected, const QString& category) {
+    ((MyNetworkManager*)_networkManager)->selectElementsOfCategory(selected, category);
+}
+
+void MyInteractor::selectNodes(const bool& selected) {
+    ((MyNetworkManager*)_networkManager)->selectNodes(selected);
+}
+
+void MyInteractor::selectNodesOfCategory(const bool& selected, const QString& category) {
+    ((MyNetworkManager*)_networkManager)->selectNodesOfCategory(selected, category);
+}
+
+void MyInteractor::selectEdges(const bool& selected) {
+    ((MyNetworkManager*)_networkManager)->selectEdges(selected);
+}
+
+void MyInteractor::selectEdgesOfCategory(const bool& selected, const QString& category) {
+    ((MyNetworkManager*)_networkManager)->selectEdgesOfCategory(selected, category);
+}
+
+void MyInteractor::setElementSelected(const QString& elementName) {
+    ((MyNetworkManager*)_networkManager)->setElementSelected(elementName);
+}
+
+void MyInteractor::deleteSelectedNetworkElements() {
+    ((MyNetworkManager*)_networkManager)->deleteSelectedNetworkElements();
+}
+
+void MyInteractor::alignSelectedNetworkElements(const QString& alignType) {
+    ((MyNetworkManager*)_networkManager)->alignSelectedNetworkElements(alignType);
+}
+
+const QList<MyNetworkElementBase*> MyInteractor::getSelectedElements() {
+    return ((MyNetworkManager*)_networkManager)->getSelectedElements();
+}
+
+MyNetworkElementBase* MyInteractor::getOneSingleSelectedElement() {
+    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
+}
+
+MyNetworkElementBase* MyInteractor::getOneSingleSelectedNode() {
+    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
+}
+
+MyNetworkElementBase* MyInteractor::getOneSingleSelectedEdge() {
+    return ((MyNetworkManager*)_networkManager)->getOneSingleSelectedElement();
+}
+
+void MyInteractor::setSceneMode(const SceneMode& sceneMode) {
+    MySceneModeElementBase::setSceneMode(sceneMode);
+    emit modeIsSet(getSceneModeAsString());
+}
+
+void MyInteractor::enableNormalMode() {
+    MySceneModeElementBase::enableNormalMode();
+    ((MyNetworkManager*)_networkManager)->enableNormalMode();
+
+    emit askForSetToolTip("");
+}
+
+void MyInteractor::enableAddNodeMode(MyPluginItemBase* style) {
+    enableNormalMode();
+    MySceneModeElementBase::enableAddNodeMode();
+    askForRemoveFeatureMenu();
+    ((MyNetworkManager*)_networkManager)->enableAddNodeMode(style);
+    
+    emit askForSetToolTip(((MyNetworkElementStyleBase*)style)->toolTipText());
+    emit addElementModeIsEnabled(style->name());
+}
+
+void MyInteractor::enableAddEdgeMode(MyPluginItemBase* style) {
+    enableNormalMode();
+    MySceneModeElementBase::enableAddEdgeMode();
+    askForRemoveFeatureMenu();
+    ((MyNetworkManager*)_networkManager)->enableAddEdgeMode(style);
+
+    emit askForSetToolTip(((MyNetworkElementStyleBase*)style)->toolTipText());
+    emit addElementModeIsEnabled(style->name());
+}
+
+void MyInteractor::enableSelectMode(const QString& elementCategory) {
+    enableNormalMode();
+    MySceneModeElementBase::enableSelectMode();
+    ((MyNetworkManager*)_networkManager)->enableSelectMode();
+
+    emit askForSetToolTip("Select" + elementCategory);
+}
+
+void MyInteractor::enableSelectNodeMode(const QString& nodeCategory) {
+    enableNormalMode();
+    MySceneModeElementBase::enableSelectNodeMode();
+    ((MyNetworkManager*)_networkManager)->enableSelectNodeMode();
+    
+    emit askForSetToolTip("Select " + nodeCategory + " nodes");
+}
+
+void MyInteractor::enableSelectEdgeMode(const QString& edgeCategory) {
+    enableNormalMode();
+    MySceneModeElementBase::enableSelectEdgeMode();
+    ((MyNetworkManager*)_networkManager)->enableSelectEdgeMode();
+    
+    emit askForSetToolTip("Select " + edgeCategory + " edges");
+}
+
+void MyInteractor::displayFeatureMenu() {
+    if (askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()) {
+        if (getOneSingleSelectedNode())
+            getOneSingleSelectedNode()->createFeatureMenu();
+        else if (getOneSingleSelectedEdge())
+            getOneSingleSelectedEdge()->createFeatureMenu();
+        else if (getSelectedElements().size()) {
+            QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), iconsDirectoryPath());
+            connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
+            askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
+        }
+        else
+            askForDisplayFeatureMenu();
+    }
+}
+
+void MyInteractor::displayFeatureMenu(QWidget* featureMenu) {
+    QString elementName = featureMenu->objectName();
+    if (((MyNetworkManager*)_networkManager)->canDisplaySingleElementFeatureMenu()) {
+        emit askForDisplayFeatureMenu(featureMenu);
+        emit singleNetworkElementFeatureMenuIsDisplayed(elementName);
+    }
+    else {
+        featureMenu->deleteLater();
+        QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), iconsDirectoryPath());
+        connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SLOT(createChangeStageCommand()));
+        emit askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
+        emit multiNetworkElementFeatureMenuIsDisplayed(elementName);
+    }
+}
+
+void MyInteractor::displaySelectionArea(const QPointF& position) {
+    ((MyNetworkManager*)_networkManager)->displaySelectionArea(position);
+}
+
+void MyInteractor::clearSelectionArea() {
+    ((MyNetworkManager*)_networkManager)->clearSelectionArea();
+    displayFeatureMenu();
+}
+
+void MyInteractor::readFromFile(const QString& importToolName) {
+    if (((MyFileManager*)fileManager())->canSaveCurrentNetwork())
+        saveCurrentNetwork();
+    ((MyPluginManager*)_pluginManager)->readFromFile(importToolName);
+}
+
+void MyInteractor::readFromFile(MyPluginItemBase* importTool) {
+    if (((MyFileManager*)fileManager())->canSaveCurrentNetwork())
+        saveCurrentNetwork();
+    ((MyPluginManager*)_pluginManager)->readFromFile(importTool);
+}
+
+void MyInteractor::writeDataToFile(const QString& exportToolName) {
+    ((MyPluginManager*)_pluginManager)->writeDataToFile(exportToolName);
+}
+
+void MyInteractor::writeDataToFile(MyPluginItemBase* exportTool) {
+    ((MyPluginManager*)_pluginManager)->writeDataToFile(exportTool);
+}
+
+void MyInteractor::writeFigureToFile(const QString& exportToolName) {
+    ((MyPluginManager*)_pluginManager)->writeFigureToFile(exportToolName);
+}
+
+void MyInteractor::writeFigureToFile(MyPluginItemBase* exportTool) {
+    ((MyPluginManager*)_pluginManager)->writeFigureToFile(exportTool);
+}
+
+void MyInteractor::saveCurrentNetwork() {
+    if (((MyFileManager*)fileManager())->lastSavedFileName().isEmpty())
+        ((MyPluginManager*)_pluginManager)->writeDataToFile(((MyFileManager*)fileManager())->currentExportTool());
+    else
+        ((MyPluginManager*)_pluginManager)->writeDataToFile(((MyFileManager*)fileManager())->currentExportTool(), ((MyFileManager*)fileManager())->currentFileName());
+}
+
+void MyInteractor::autoLayout(MyPluginItemBase* autoLayoutEngine) {
+    ((MyPluginManager*)_pluginManager)->autoLayout(autoLayoutEngine);
 }
 
 QList<QAbstractButton*> MyInteractor::getToolbarMenuButtons() {
@@ -626,6 +473,17 @@ void MyInteractor::addDefaultEdgeStyle() {
     }
 }
 
-const bool MyInteractor::isElementNameAlreadyUsed(const QString& elementName) {
-    return ((MyNetworkManager*)_networkManager)->isElementNameAlreadyUsed(elementName);
+void MyInteractor::createChangeStageCommand() {
+    QJsonObject currentStageInfo = getNetworkElementsAndColorInfo();
+    if (undoStack()->count() > undoStack()->index()) {
+        const QUndoCommand* indexCommand = undoStack()->command(undoStack()->index());
+        _stageInfo = ((MyChangeStageCommand*)indexCommand)->previousStageInfo();
+    }
+    if (currentStageInfo != _stageInfo) {
+        ((MyFileManager*)fileManager())->setCurrentNetworkUnsaved(true);
+        MyChangeStageCommand* changeStageCommand = new MyChangeStageCommand(_stageInfo, currentStageInfo);
+        ((MyUndoStack*)undoStack())->addCommand(changeStageCommand);
+        connect(changeStageCommand, SIGNAL(askForCreateNetwork(const QJsonObject&)), this, SLOT(createNetwork(const QJsonObject&)));
+        _stageInfo = currentStageInfo;
+    }
 }

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -24,8 +24,8 @@ public:
     QDir iconsDirectory();
     const QString iconsDirectoryPath();
     QList<MyPluginItemBase*>& pluginItems();
-    const QStringList listOfPluginItemNames(const QString& type);
-    const QStringList listOfPluginItemCategories(const QString& type);
+    QStringList listOfPluginItemNames(const QString& type);
+    QStringList listOfPluginItemCategories(const QString& type);
     void addPluginItem(MyPluginItemBase* pluginItem);
     QObject* networkManager();
     QObject* fileManager();

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -67,7 +67,7 @@ public:
     void setElementSelected(const QString& elementName);
     void deleteSelectedNetworkElements();
     void alignSelectedNetworkElements(const QString& alignType);
-    void displayFeatureMenu();
+    void updateFeatureMenu();
     void displayFeatureMenu(QWidget* featureMenu);
     void displaySelectionArea(const QPointF& position);
     void clearSelectionArea();
@@ -90,7 +90,7 @@ signals:
     void askForClearScene();
     void askForResetScale();
     void askForSetToolTip(const QString& toolTip);
-    void askForDisplayFeatureMenu();
+    void askForDisplayNullFeatureMenu();
     void askForDisplayFeatureMenu(QWidget*);
     void askForRemoveFeatureMenu();
     QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -1,14 +1,15 @@
 #ifndef __NEGUI_INTERACTOR_H
 #define __NEGUI_INTERACTOR_H
 
-#include "negui_network_element_base.h"
 #include "negui_scene_mode_element_base.h"
+#include "negui_plugin_item_base.h"
 
 #include <QObject>
 #include <QDir>
 #include <QUndoStack>
 #include <QWidgetAction>
 #include <QAbstractButton>
+#include <QGraphicsItem>
 
 class MyInteractor : public QObject, public MySceneModeElementBase {
     Q_OBJECT
@@ -101,10 +102,6 @@ public slots:
     void addNewNode(const QPointF& position);
     void deleteSelectedNetworkElements();
     void alignSelectedNetworkElements(const QString& alignType);
-    const QList<MyNetworkElementBase*> getSelectedElements();
-    MyNetworkElementBase* getOneSingleSelectedElement();
-    MyNetworkElementBase* getOneSingleSelectedNode();
-    MyNetworkElementBase* getOneSingleSelectedEdge();
     void setElementSelected(const QString& elementName);
     void selectElements(const bool& selected);
     void selectElementsOfCategory(const bool& selected, const QString& category);

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -93,6 +93,7 @@ signals:
     void askForDisplayFeatureMenu(QWidget*);
     void askForRemoveFeatureMenu();
     void askForEnableFeatureMenuDisplay();
+    QWidget* askForCurrentlyBeingDisplayedFeatureMenu();
     bool askForWhetherFeatureMenuCanBeDisplayed();
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
     void modeIsSet(const QString&);

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -7,7 +7,6 @@
 #include <QObject>
 #include <QDir>
 #include <QUndoStack>
-#include <QWidgetAction>
 #include <QAbstractButton>
 #include <QGraphicsItem>
 
@@ -17,41 +16,67 @@ class MyInteractor : public QObject, public MySceneModeElementBase {
 public:
     
     MyInteractor(QObject *parent = nullptr);
-    
-    // undo stack
+
     QUndoStack* undoStack();
     void setUndoStack();
-
+    QDir applicationDirectory();
+    const QString applicationDirectoryPath();
+    QDir iconsDirectory();
+    const QString iconsDirectoryPath();
+    QList<MyPluginItemBase*>& pluginItems();
+    const QStringList listOfPluginItemNames(const QString& type);
+    const QStringList listOfPluginItemCategories(const QString& type);
+    void addPluginItem(MyPluginItemBase* pluginItem);
     QObject* networkManager();
-
     QObject* fileManager();
-
     QObject* menuButtonManager();
-    
-    // modes
     void setSceneMode(const SceneMode& sceneMode) override;
-
-    // network
+    void enableSelectMode(const QString& elementCategory = "");
+    void enableSelectNodeMode(const QString& nodeCategory = "");
+    void enableSelectEdgeMode(const QString& edgeCategory = "");
+    void createNetwork(const QJsonObject &json);
     void resetNetworkCanvas();
-    void resetCanvas();
     void resetNetwork();
+    void resetCanvas();
     void setBackground(const QJsonObject &json);
-    
-    // nodes
     void addNodes(const QJsonObject &json);
     void addNode(const QJsonObject& json);
-    void updateNodeParents();
+    void addNewNode(const QPointF& position);
     void clearNodesInfo();
-    
-    // edges
     void addEdges(const QJsonObject &json);
     void addEdge(const QJsonObject& json);
     void clearEdgesInfo();
+    const bool areSelectedElementsCopyable();
+    const bool areSelectedElementsCuttable();
+    const bool areSelectedElementsAlignable();
+    const bool areAnyElementsCopied();
+    const bool areAnyElementsSelected();
+    void copySelectedNetworkElements();
+    void cutSelectedNetworkElements();
+    void pasteCopiedNetworkElements();
+    void pasteCopiedNetworkElements(const QPointF& position);
     void resetCopiedNetworkElements();
-
-    void setApplicationDirectory();
-    QDir applicationDirectory();
-    QDir iconsDirectory();
+    QJsonObject getNetworkElementsAndColorInfo();
+    QJsonObject exportNetworkInfo();
+    void selectElements(const bool& selected);
+    void selectElementsOfCategory(const bool& selected, const QString& category);
+    void selectNodes(const bool& selected);
+    void selectNodesOfCategory(const bool& selected, const QString& category);
+    void selectEdges(const bool& selected);
+    void selectEdgesOfCategory(const bool& selected, const QString& category);
+    void setElementSelected(const QString& elementName);
+    void deleteSelectedNetworkElements();
+    void alignSelectedNetworkElements(const QString& alignType);
+    void displayFeatureMenu();
+    void displayFeatureMenu(QWidget* featureMenu);
+    void displaySelectionArea(const QPointF& position);
+    void clearSelectionArea();
+    void readFromFile(const QString& importToolName);
+    void writeDataToFile(const QString& exportToolName);
+    void writeFigureToFile(const QString& exportToolName);
+    QList<QAbstractButton*> getToolbarMenuButtons();
+    QList<QAbstractButton*> getModeMenuButtons();
+    void createChangeStageCommand();
 
 signals:
 
@@ -85,94 +110,28 @@ signals:
     void singleNetworkElementFeatureMenuIsDisplayed(const QString&);
     void multiNetworkElementFeatureMenuIsDisplayed(const QString&);
 
-    void enterKeyIsPressed();
-    
 public slots:
-    
-    // menus
-    QList<QAbstractButton*> getToolbarMenuButtons();
-    QList<QAbstractButton*> getModeMenuButtons();
-    
-    // network
-    void setNewNetworkCanvas();
-    void createNetwork(const QJsonObject &json);
-    QJsonObject exportNetworkInfo();
-    
-    // network elements
-    void addNewNode(const QPointF& position);
-    void deleteSelectedNetworkElements();
-    void alignSelectedNetworkElements(const QString& alignType);
-    void setElementSelected(const QString& elementName);
-    void selectElements(const bool& selected);
-    void selectElementsOfCategory(const bool& selected, const QString& category);
-    void selectNodes(const bool& selected);
-    void selectNodesOfCategory(const bool& selected, const QString& category);
-    void selectEdges(const bool& selected);
-    void selectEdgesOfCategory(const bool& selected, const QString& category);
-    const bool areSelectedElementsCopyable();
-    const bool areSelectedElementsCuttable();
-    const bool areSelectedElementsAlignable();
-    const bool areAnyElementsCopied();
-    const bool areAnyElementsSelected();
-    const QString applicationDirectoryPath();
-    const QString iconsDirectoryPath();
-    QJsonObject getNetworkElementsAndColorInfo();
-    
-    // modes
+
     void enableNormalMode() override;
     void enableAddNodeMode(MyPluginItemBase* style);
     void enableAddEdgeMode(MyPluginItemBase* style);
-    void enableSelectMode(const QString& elementCategory = "");
-    void enableSelectNodeMode(const QString& nodeCategory = "");
-    void enableSelectEdgeMode(const QString& edgeCategory = "");
-
-    void displayFeatureMenu();
-    void displayFeatureMenu(QWidget* featureMenu);
-
-    void displaySelectionArea(const QPointF& position);
-    void clearSelectionArea();
-
-    void pasteCopiedNetworkElements();
-    void pasteCopiedNetworkElements(const QPointF& position);
-
-    // plugins
-    QList<MyPluginItemBase*>& pluginItems();
-    const QStringList listOfPluginItemNames(const QString type);
-    const QStringList listOfPluginItemCategories(const QString type);
-    void addPluginItem(MyPluginItemBase* pluginItem);
-    
-private slots:
-
-    void readFromFile(const QString& importToolName);
+    void setNewNetworkCanvas();
     void readFromFile(MyPluginItemBase* importToo);
-    void writeDataToFile(const QString& exportToolName);
-    void writeDataToFile(MyPluginItemBase* exportTool);
-    void writeFigureToFile(const QString& exportToolName);
-    void writeFigureToFile(MyPluginItemBase* exportTool);
     void saveCurrentNetwork();
+    void writeDataToFile(MyPluginItemBase* exportTool);
+    void writeFigureToFile(MyPluginItemBase* exportTool);
     void autoLayout(MyPluginItemBase* autoLayoutEngine);
-    void createChangeStageCommand();
-    void copySelectedNetworkElements();
-    void cutSelectedNetworkElements();
+
     
 protected:
 
-    // plugins
     void setPluginManager();
     void loadPlugins();
-
-    // network manager
     void setNetworkManager();
-
-    // file manager
     void setFileManager();
-
+    void setMenuButtonManager();
     void initializeStageInfo();
 
-    // menu buttons
-    void setMenuButtonManager();
-
-    QDir _applicationDirectory;
     QUndoStack* _undoStack;
     QJsonObject _stageInfo;
     QObject* _networkManager;

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -76,6 +76,7 @@ public:
     void writeFigureToFile(const QString& exportToolName);
     QList<QAbstractButton*> getToolbarMenuButtons();
     QList<QAbstractButton*> getModeMenuButtons();
+    void addDefaultNetworkElementStyles();
     void createChangeStageCommand();
 
 signals:

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -20,6 +20,8 @@ public:
     // undo stack
     QUndoStack* undoStack();
 
+    QObject* networkManager();
+
     QObject* fileManager();
     
     // modes
@@ -67,7 +69,6 @@ signals:
     void askForExportFigure(const QString& fileName, const QString& fileExtension);
     void askForAddGraphicsItem(QGraphicsItem*);
     void askForRemoveGraphicsItem(QGraphicsItem*);
-    const QRectF askForNetworkExtents();
     const QString askForNetworkBackgroundColor();
     void askForSetNetworkBackgroundColor(const QString&);
     void askForClearScene();
@@ -193,51 +194,22 @@ protected:
     void setPluginManager();
     void loadPlugins();
 
+    // network manager
+    void setNetworkManager();
+
     // file manager
     void setFileManager();
-
-    // network element selector
-    void setNetworkElementSelector();
     
     // menu buttons
     void addDefaultNodeStyle();
     void addDefaultEdgeStyle();
-    
-    // element styles
-    MyNetworkElementStyleBase* _nodeStyle;
-    MyNetworkElementStyleBase* _edgeStyle;
-
-    // copied elements
-    QList<MyNetworkElementBase*> _copiedNetworkElements;
-
-    // copied styles
-    MyNetworkElementStyleBase* _copiedNodeStyle;
-    MyNetworkElementStyleBase* _copiedEdgeStyle;
 
     QDir _applicationDirectory;
-    
-    // undo stack
     QUndoStack* _undoStack;
-    
-    // elements
-    QList<MyNetworkElementBase*> _nodes;
-    QList<MyNetworkElementBase*> _edges;
-    
-    // builder
-    QObject* _newEdgeBuilder;
-    QGraphicsItem* _selectionAreaGraphicsItem;
-    
-    // network
     QJsonObject _stageInfo;
-
-    // file
+    QObject* _networkManager;
     QObject* _pluginManager;
-
-    // file
     QObject* _fileManager;
-
-    // select
-    QObject* _networkElementSelector;
 };
 
 #endif

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -68,7 +68,6 @@ public:
     void deleteSelectedNetworkElements();
     void alignSelectedNetworkElements(const QString& alignType);
     void updateFeatureMenu();
-    void displayFeatureMenu(QWidget* featureMenu);
     void displaySelectionArea(const QPointF& position);
     void clearSelectionArea();
     void readFromFile(const QString& importToolName);
@@ -93,7 +92,8 @@ signals:
     void askForDisplayNullFeatureMenu();
     void askForDisplayFeatureMenu(QWidget*);
     void askForRemoveFeatureMenu();
-    QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
+    void askForEnableFeatureMenuDisplay();
+    bool askForWhetherFeatureMenuCanBeDisplayed();
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
     void modeIsSet(const QString&);
     void currentFileNameIsUpdated(const QString&);
@@ -108,8 +108,6 @@ signals:
     void askForSettingWorkingDirectoryPath(const QString&);
     void askForAdjustConnectedEdgesOfNodes();
     void askForAdjustExtentsOfNodes();
-    void singleNetworkElementFeatureMenuIsDisplayed(const QString&);
-    void multiNetworkElementFeatureMenuIsDisplayed(const QString&);
 
 public slots:
 

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -24,6 +24,8 @@ public:
     QObject* networkManager();
 
     QObject* fileManager();
+
+    QObject* menuButtonManager();
     
     // modes
     void setSceneMode(const SceneMode& sceneMode) override;
@@ -169,10 +171,9 @@ protected:
     void setFileManager();
 
     void initializeStageInfo();
-    
+
     // menu buttons
-    void addDefaultNodeStyle();
-    void addDefaultEdgeStyle();
+    void setMenuButtonManager();
 
     QDir _applicationDirectory;
     QUndoStack* _undoStack;
@@ -180,6 +181,7 @@ protected:
     QObject* _networkManager;
     QObject* _pluginManager;
     QObject* _fileManager;
+    QObject* _menuButtonManager;
 };
 
 #endif

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -19,6 +19,7 @@ public:
     
     // undo stack
     QUndoStack* undoStack();
+    void setUndoStack();
 
     QObject* networkManager();
 
@@ -34,32 +35,18 @@ public:
     void setBackground(const QJsonObject &json);
     
     // nodes
-    QList<MyNetworkElementBase*>& nodes();
     void addNodes(const QJsonObject &json);
     void addNode(const QJsonObject& json);
-    void addNode(MyNetworkElementBase* node);
-    void removeNode(MyNetworkElementBase* node);
     void updateNodeParents();
     void clearNodesInfo();
-    void setNodeStyle(MyNetworkElementStyleBase* style);
-    MyNetworkElementStyleBase* nodeStyle();
-    MyNetworkElementStyleBase* copiedNodeStyle();
     
     // edges
-    QList<MyNetworkElementBase*>& edges();
     void addEdges(const QJsonObject &json);
     void addEdge(const QJsonObject& json);
-    void addEdge(MyNetworkElementBase* edge);
-    void removeEdge(MyNetworkElementBase* edge);
     void clearEdgesInfo();
-    void setEdgeStyle(MyNetworkElementStyleBase* style);
-    MyNetworkElementStyleBase* edgeStyle();
-    MyNetworkElementStyleBase* copiedEdgeStyle();
-    QList<MyNetworkElementBase*> copiedNetworkElements();
     void resetCopiedNetworkElements();
-    void deleteNewEdgeBuilder();
-    bool edgeExists(MyNetworkElementBase* n1, MyNetworkElementBase* n2);
 
+    void setApplicationDirectory();
     QDir applicationDirectory();
     QDir iconsDirectory();
 
@@ -110,18 +97,12 @@ public slots:
     
     // network elements
     void addNewNode(const QPointF& position);
-    void addNewEdge(MyNetworkElementBase* element);
-    void deleteNode(MyNetworkElementBase* node);
-    void deleteEdge(MyNetworkElementBase* edge);
     void deleteSelectedNetworkElements();
     void alignSelectedNetworkElements(const QString& alignType);
     const QList<MyNetworkElementBase*> getSelectedElements();
-    const QList<MyNetworkElementBase*> getSelectedNodes();
-    const QList<MyNetworkElementBase*> getSelectedEdges();
     MyNetworkElementBase* getOneSingleSelectedElement();
     MyNetworkElementBase* getOneSingleSelectedNode();
     MyNetworkElementBase* getOneSingleSelectedEdge();
-    void changeElementSelectionsStatus(MyNetworkElementBase* element);
     void setElementSelected(const QString& elementName);
     void selectElements(const bool& selected);
     void selectElementsOfCategory(const bool& selected, const QString& category);
@@ -129,10 +110,6 @@ public slots:
     void selectNodesOfCategory(const bool& selected, const QString& category);
     void selectEdges(const bool& selected);
     void selectEdgesOfCategory(const bool& selected, const QString& category);
-    void setCopiedNode(MyNetworkElementBase* node);
-    void setCutNode(MyNetworkElementBase* node);
-    void setCopiedNodeStyle(MyNetworkElementStyleBase* style);
-    void setCopiedEdgeStyle(MyNetworkElementStyleBase* style);
     const bool areSelectedElementsCopyable();
     const bool areSelectedElementsCuttable();
     const bool areSelectedElementsAlignable();
@@ -141,7 +118,6 @@ public slots:
     const QString applicationDirectoryPath();
     const QString iconsDirectoryPath();
     QJsonObject getNetworkElementsAndColorInfo();
-    void moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance);
     
     // modes
     void enableNormalMode() override;
@@ -177,16 +153,8 @@ private slots:
     void saveCurrentNetwork();
     void autoLayout(MyPluginItemBase* autoLayoutEngine);
     void createChangeStageCommand();
-    void createSelectionAreaGraphicsItem(const QPointF& position);
-    void selectSelectionAreaCoveredNodes();
-    void selectSelectionAreaCoveredEdges();
-    const bool isSetCopiedNodeStyle();
-    void pasteCopiedNodeStyle(MyNetworkElementBase* element);
-    const bool isSetCopiedEdgeStyle();
-    void pasteCopiedEdgeStyle(MyNetworkElementBase* element);
     void copySelectedNetworkElements();
     void cutSelectedNetworkElements();
-    const bool isElementNameAlreadyUsed(const QString& elementName);
     
 protected:
 
@@ -199,6 +167,8 @@ protected:
 
     // file manager
     void setFileManager();
+
+    void initializeStageInfo();
     
     // menu buttons
     void addDefaultNodeStyle();

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -76,18 +76,18 @@ void MyNetworkEditorWidget::setInteractions() {
     connect((MyInteractor*)interactor(), SIGNAL(pasteElementsStatusChanged(const bool&)), this, SIGNAL(pasteElementsStatusChanged(const bool&)));
     connect(this, QOverload<>::of(&MyNetworkEditorWidget::askForSelectAllElements), (MyInteractor*)interactor(), [this] () {
         ((MyInteractor*)this->interactor())->selectElements(true);
-        ((MyInteractor*)this->interactor())->displayFeatureMenu();
+        ((MyInteractor*)this->interactor())->updateFeatureMenu();
     });
     connect(this, QOverload<const QString&>::of(&MyNetworkEditorWidget::askForSelectAllElements), (MyInteractor*)interactor(), [this] (const QString& category) {
         ((MyInteractor*)this->interactor())->selectElementsOfCategory(true, category);
-        ((MyInteractor*)this->interactor())->displayFeatureMenu();
+        ((MyInteractor*)this->interactor())->updateFeatureMenu();
     });
     connect(this, SIGNAL(askForZoomIn()), (MyGraphicsView*)view(), SLOT(zoomIn()));
     connect(this, SIGNAL(askForZoomOut()), (MyGraphicsView*)view(), SLOT(zoomOut()));
 
     /// feature menu
     // display feature menu
-    connect((MyInteractor*)interactor(), SIGNAL(askForDisplayFeatureMenu()), this, SLOT(displayFeatureMenu()));
+    connect((MyInteractor*)interactor(), SIGNAL(askForDisplayNullFeatureMenu()), this, SLOT(displayNullFeatureMenu()));
     connect((MyInteractor*)interactor(), SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SLOT(displayFeatureMenu(QWidget*)));
     connect((MyInteractor*)interactor(), SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
     connect((MyInteractor*)interactor(), &MyInteractor::askForCurrentlyBeingDisplayedNetworkElementFeatureMenu, this, [this] () { return featureMenu(); } );
@@ -152,7 +152,7 @@ void MyNetworkEditorWidget::setInteractions() {
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::mouseLeftButtonIsReleased, this, [this] () { ((MyInteractor*)interactor())->clearSelectionArea(); });
 
     // display null feature menu
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(escapeKeyIsPressed()), this, SLOT(displayFeatureMenu()));
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(escapeKeyIsPressed()), this, SLOT(displayNullFeatureMenu()));
 
     // change mode
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::escapeKeyIsPressed, (MyInteractor*)interactor(), &MyInteractor::enableNormalMode);
@@ -223,7 +223,7 @@ const qreal& MyNetworkEditorWidget::layoutMenuRow() {
     return _layoutMenuRow;
 }
 
-void MyNetworkEditorWidget::displayFeatureMenu() {
+void MyNetworkEditorWidget::displayNullFeatureMenu() {
     if (featureMenu())
         displayFeatureMenu(new MyNullFeatureMenu(((MyInteractor *) interactor())->iconsDirectory().path()));
 }

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -149,9 +149,6 @@ void MyNetworkEditorWidget::setInteractions() {
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::mousePressedLeftButtonIsMoved, this, [this] (const QPointF& position) { ((MyInteractor*)interactor())->displaySelectionArea(position); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::mouseLeftButtonIsReleased, this, [this] () { ((MyInteractor*)interactor())->clearSelectionArea(); });
 
-    // display null feature menu
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(escapeKeyIsPressed()), this, SLOT(displayNullFeatureMenu()));
-
     // change mode
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::escapeKeyIsPressed, (MyInteractor*)interactor(), &MyInteractor::enableNormalMode);
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForEnableNormalMode, (MyInteractor*)interactor(), &MyInteractor::enableNormalMode);

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -57,22 +57,22 @@ void MyNetworkEditorWidget::setWidgets() {
 void MyNetworkEditorWidget::setInteractions() {
     /// main widget
     // menubar
-    connect(this, SIGNAL(askForSetNewNetworkCanvas()), (MyInteractor*)interactor(), SLOT(setNewNetworkCanvas()));
-    connect(this, SIGNAL(askForListOfPluginItemNames(const QString&)), (MyInteractor*)interactor(), SLOT(listOfPluginItemNames(const QString&)));
-    connect(this, SIGNAL(askForListOfPluginItemCategories(const QString&)), (MyInteractor*)interactor(), SLOT(listOfPluginItemCategories(const QString&)));
-    connect(this, SIGNAL(askForReadFromFile(const QString&)), (MyInteractor*)interactor(), SLOT(readFromFile(const QString&)));
-    connect(this, SIGNAL(askForSaveCurrentNetwork()), (MyInteractor*)interactor(), SLOT(saveCurrentNetwork()));
-    connect(this, SIGNAL(askForWriteDataToFile(const QString&)), (MyInteractor*)interactor(), SLOT(writeDataToFile(const QString&)));
-    connect(this, SIGNAL(askForWriteFigureToFile(const QString&)), (MyInteractor*)interactor(), SLOT(writeFigureToFile(const QString&)));
+    connect(this, &MyNetworkEditorWidget::askForSetNewNetworkCanvas, this, [this] () { ((MyInteractor*)interactor())->setNewNetworkCanvas(); });
+    connect(this, &MyNetworkEditorWidget::askForListOfPluginItemNames, this, [this] (const QString& type) { ((MyInteractor*)interactor())->listOfPluginItemNames(type); });
+    connect(this, &MyNetworkEditorWidget::askForListOfPluginItemCategories, this, [this] (const QString& type) { ((MyInteractor*)interactor())->listOfPluginItemCategories(type); });
+    connect(this, &MyNetworkEditorWidget::askForReadFromFile, this, [this] (const QString& importToolName) { ((MyInteractor*)interactor())->readFromFile(importToolName); });
+    connect(this, &MyNetworkEditorWidget::askForSaveCurrentNetwork, this, [this] () { ((MyInteractor*)interactor())->saveCurrentNetwork(); });
+    connect(this, &MyNetworkEditorWidget::askForWriteDataToFile, this, [this] (const QString& exportToolName){ ((MyInteractor*)interactor())->writeDataToFile(exportToolName); });
+    connect(this, &MyNetworkEditorWidget::askForWriteFigureToFile, this, [this] (const QString& exportToolName) { ((MyInteractor*)interactor())->writeFigureToFile(exportToolName); });
     connect(this, SIGNAL(askForTriggerUndoAction()), ((MyInteractor*)interactor())->undoStack(), SLOT(undo()));
     connect(((MyInteractor*)interactor())->undoStack(), SIGNAL(canUndoChanged(const bool&)), this, SIGNAL(canUndoChanged(const bool&)));
     connect(this, SIGNAL(askForTriggerRedoAction()), ((MyInteractor*)interactor())->undoStack(), SLOT(redo()));
     connect(((MyInteractor*)interactor())->undoStack(), SIGNAL(canRedoChanged(const bool&)), this, SIGNAL(canRedoChanged(const bool&)));
-    connect(this, SIGNAL(askForCutSelectedNetworkElements()), (MyInteractor*)interactor(), SLOT(cutSelectedNetworkElements()));
+    connect(this, &MyNetworkEditorWidget::askForCutSelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->cutSelectedNetworkElements(); });
     connect((MyInteractor*)interactor(), SIGNAL(elementsCuttableStatusChanged(const bool&)), this, SIGNAL(elementsCuttableStatusChanged(const bool&)));
-    connect(this, SIGNAL(askForCopySelectedNetworkElements()), (MyInteractor*)interactor(), SLOT(copySelectedNetworkElements()));
+    connect(this, &MyNetworkEditorWidget::askForCopySelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->copySelectedNetworkElements(); });
     connect((MyInteractor*)interactor(), SIGNAL(elementsCopyableStatusChanged(const bool&)), this, SIGNAL(elementsCopyableStatusChanged(const bool&)));
-    connect(this, SIGNAL(askForPasteCopiedNetworkElements()), (MyInteractor*)interactor(), SLOT(pasteCopiedNetworkElements()));
+    connect(this, &MyNetworkEditorWidget::askForPasteCopiedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->pasteCopiedNetworkElements(); });
     connect((MyInteractor*)interactor(), SIGNAL(pasteElementsStatusChanged(const bool&)), this, SIGNAL(pasteElementsStatusChanged(const bool&)));
     connect(this, QOverload<>::of(&MyNetworkEditorWidget::askForSelectAllElements), (MyInteractor*)interactor(), [this] () {
         ((MyInteractor*)this->interactor())->selectElements(true);
@@ -107,12 +107,9 @@ void MyNetworkEditorWidget::setInteractions() {
     // reset scale
     connect((MyInteractor*)interactor(), SIGNAL(askForResetScale()), (MyGraphicsView*)view(), SLOT(resetScale()));
 
-    // enter key pressed
-    connect((MyGraphicsView*)view(), SIGNAL(enterKeyIsPressed()), (MyInteractor*)interactor(), SIGNAL(enterKeyIsPressed()));
-
     /// graphics scene
     // change stage command
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(askForCreateChangeStageCommand()), (MyInteractor*)interactor(), SLOT(createChangeStageCommand()));
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForCreateChangeStageCommand, this, [this] () { ((MyInteractor*)interactor())->createChangeStageCommand(); });
 
     // set scene mode
     connect((MyInteractor*)interactor(), &MyInteractor::modeIsSet, ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), [this] (const QString& mode) { ((MyGraphicsScene*)((MyGraphicsView*)view())->scene())->setSceneMode(mode); });
@@ -147,12 +144,12 @@ void MyNetworkEditorWidget::setInteractions() {
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForSelectAll, (MyInteractor*)interactor(), [this] () { ((MyInteractor*)this->interactor())->selectElements(true); });
     
     // add node
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(mouseLeftButtonIsPressed(const QPointF&)), (MyInteractor*)interactor(), SLOT(addNewNode(const QPointF&)));
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::mouseLeftButtonIsPressed, this, [this] (const QPointF& position) { ((MyInteractor*)interactor())->addNewNode(position); });
 
     // display the element selection rectangle
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(mouseLeftButtonIsPressed(const QPointF&)), (MyInteractor*)interactor(), SLOT(displaySelectionArea(const QPointF&)));
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(mousePressedLeftButtonIsMoved(const QPointF&)), (MyInteractor*)interactor(), SLOT(displaySelectionArea(const QPointF&)));
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(mouseLeftButtonIsReleased()), (MyInteractor*)interactor(), SLOT(clearSelectionArea()));
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::mouseLeftButtonIsPressed, this, [this] (const QPointF& position) { ((MyInteractor*)interactor())->displaySelectionArea(position); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::mousePressedLeftButtonIsMoved, this, [this] (const QPointF& position) { ((MyInteractor*)interactor())->displaySelectionArea(position); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::mouseLeftButtonIsReleased, this, [this] () { ((MyInteractor*)interactor())->clearSelectionArea(); });
 
     // display null feature menu
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SIGNAL(escapeKeyIsPressed()), this, SLOT(displayFeatureMenu()));
@@ -162,16 +159,16 @@ void MyNetworkEditorWidget::setInteractions() {
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForEnableNormalMode, (MyInteractor*)interactor(), &MyInteractor::enableNormalMode);
 
     // context menu
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForWhetherSelectedElementsAreCopyable()), (MyInteractor*)interactor(), SLOT(areSelectedElementsCopyable()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForWhetherSelectedElementsAreCuttable()), (MyInteractor*)interactor(), SLOT(areSelectedElementsCuttable()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForWhetherAnyElementsAreCopied()), (MyInteractor*)interactor(), SLOT(areAnyElementsCopied()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForWhetherAnyElementsAreSelected()), (MyInteractor*)interactor(), SLOT(areAnyElementsSelected()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForWhetherAnyElementsAreAlignable()), (MyInteractor*)interactor(), SLOT(areSelectedElementsAlignable()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForCopySelectedNetworkElements()), (MyInteractor*)interactor(), SLOT(copySelectedNetworkElements()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForCutSelectedNetworkElements()), (MyInteractor*)interactor(), SLOT(cutSelectedNetworkElements()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForPasteCopiedNetworkElements(const QPointF &)), (MyInteractor*)interactor(), SLOT(pasteCopiedNetworkElements(const QPointF &)));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForDeleteSelectedNetworkElements()), (MyInteractor*)interactor(), SLOT(deleteSelectedNetworkElements()));
-    connect(((MyGraphicsView*)view())->scene(), SIGNAL(askForAlignSelectedNetworkElements(const QString&)), (MyInteractor*)interactor(), SLOT(alignSelectedNetworkElements(const QString&)));
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherSelectedElementsAreCopyable, this, [this] { ((MyInteractor*)interactor())->areSelectedElementsCopyable(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherSelectedElementsAreCuttable, this, [this] { ((MyInteractor*)interactor())->areSelectedElementsCuttable(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreCopied, this, [this] () { ((MyInteractor*)interactor())->areAnyElementsCopied(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreSelected, this, [this] () { ((MyInteractor*)interactor())->areAnyElementsSelected(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreAlignable, this, [this] () { ((MyInteractor*)interactor())->areSelectedElementsAlignable(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForCopySelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->copySelectedNetworkElements(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForCutSelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->cutSelectedNetworkElements(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForPasteCopiedNetworkElements, this, [this] (const QPointF & position) { ((MyInteractor*)interactor())->pasteCopiedNetworkElements(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForDeleteSelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->deleteSelectedNetworkElements(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForAlignSelectedNetworkElements, this, [this] (const QString& type)  { ((MyInteractor*)interactor())->alignSelectedNetworkElements(type); });
     connect((MyInteractor*)interactor(), SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), ((MyGraphicsView*)view())->scene(), SLOT(displayContextMenu(const QPointF&)));
 
     // status bar

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -127,9 +127,6 @@ void MyNetworkEditorWidget::setInteractions() {
     connect((MyInteractor*)interactor(), SIGNAL(askForNetworkBackgroundColor()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(backgroundColor()));
     connect((MyInteractor*)interactor(), SIGNAL(askForSetNetworkBackgroundColor(const QString&)), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(setBackgroundColor(const QString&)));
 
-    // network extents
-    connect((MyInteractor*)interactor(), SIGNAL(askForNetworkExtents()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(networkExtents()));
-
     // reset scene
     connect((MyInteractor*)interactor(), SIGNAL(askForClearScene()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(clearScene()));
     connect((MyInteractor*)interactor(), SIGNAL(askForClearScene()), this, SLOT(removeFeatureMenu()));

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -89,6 +89,7 @@ void MyNetworkEditorWidget::setInteractions() {
     connect((MyInteractor*)interactor(), SIGNAL(askForRemoveFeatureMenu()), this, SLOT(removeFeatureMenu()));
     connect((MyInteractor*)interactor(), &MyInteractor::askForWhetherFeatureMenuCanBeDisplayed, this, [this] () { return _canDisplayFeatureMenu; } );
     connect((MyInteractor*)interactor(), &MyInteractor::askForEnableFeatureMenuDisplay, this, [this] () { _canDisplayFeatureMenu = true; } );
+    connect((MyInteractor*)interactor(), &MyInteractor::askForCurrentlyBeingDisplayedFeatureMenu, this, [this] () { return featureMenu(); });
 
     /// mode menu
     // set mode

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -58,8 +58,8 @@ void MyNetworkEditorWidget::setInteractions() {
     /// main widget
     // menubar
     connect(this, &MyNetworkEditorWidget::askForSetNewNetworkCanvas, this, [this] () { ((MyInteractor*)interactor())->setNewNetworkCanvas(); });
-    connect(this, &MyNetworkEditorWidget::askForListOfPluginItemNames, this, [this] (const QString& type) { ((MyInteractor*)interactor())->listOfPluginItemNames(type); });
-    connect(this, &MyNetworkEditorWidget::askForListOfPluginItemCategories, this, [this] (const QString& type) { ((MyInteractor*)interactor())->listOfPluginItemCategories(type); });
+    connect(this, &MyNetworkEditorWidget::askForListOfPluginItemNames, this, [this] (const QString& type) { return ((MyInteractor*)interactor())->listOfPluginItemNames(type); });
+    connect(this, &MyNetworkEditorWidget::askForListOfPluginItemCategories, this, [this] (const QString& type) { return ((MyInteractor*)interactor())->listOfPluginItemCategories(type); });
     connect(this, &MyNetworkEditorWidget::askForReadFromFile, this, [this] (const QString& importToolName) { ((MyInteractor*)interactor())->readFromFile(importToolName); });
     connect(this, &MyNetworkEditorWidget::askForSaveCurrentNetwork, this, [this] () { ((MyInteractor*)interactor())->saveCurrentNetwork(); });
     connect(this, &MyNetworkEditorWidget::askForWriteDataToFile, this, [this] (const QString& exportToolName){ ((MyInteractor*)interactor())->writeDataToFile(exportToolName); });
@@ -159,11 +159,11 @@ void MyNetworkEditorWidget::setInteractions() {
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForEnableNormalMode, (MyInteractor*)interactor(), &MyInteractor::enableNormalMode);
 
     // context menu
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherSelectedElementsAreCopyable, this, [this] { ((MyInteractor*)interactor())->areSelectedElementsCopyable(); });
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherSelectedElementsAreCuttable, this, [this] { ((MyInteractor*)interactor())->areSelectedElementsCuttable(); });
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreCopied, this, [this] () { ((MyInteractor*)interactor())->areAnyElementsCopied(); });
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreSelected, this, [this] () { ((MyInteractor*)interactor())->areAnyElementsSelected(); });
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreAlignable, this, [this] () { ((MyInteractor*)interactor())->areSelectedElementsAlignable(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherSelectedElementsAreCopyable, this, [this] () { return ((MyInteractor*)interactor())->areSelectedElementsCopyable(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherSelectedElementsAreCuttable, this, [this] () { return ((MyInteractor*)interactor())->areSelectedElementsCuttable(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreCopied, this, [this] () { return ((MyInteractor*)interactor())->areAnyElementsCopied(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreSelected, this, [this] () { return ((MyInteractor*)interactor())->areAnyElementsSelected(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreAlignable, this, [this] () { return ((MyInteractor*)interactor())->areSelectedElementsAlignable(); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForCopySelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->copySelectedNetworkElements(); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForCutSelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->cutSelectedNetworkElements(); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForPasteCopiedNetworkElements, this, [this] (const QPointF & position) { ((MyInteractor*)interactor())->pasteCopiedNetworkElements(); });

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -49,7 +49,7 @@ signals:
 
 private slots:
 
-    void displayFeatureMenu();
+    void displayNullFeatureMenu();
     void displayFeatureMenu(QWidget* featureMenu);
     void removeFeatureMenu();
 

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -26,8 +26,8 @@ public:
 signals:
 
     void askForSetNewNetworkCanvas();
-    const QStringList askForListOfPluginItemNames(const QString&);
-    const QStringList askForListOfPluginItemCategories(const QString&);
+    QStringList askForListOfPluginItemNames(const QString&);
+    QStringList askForListOfPluginItemCategories(const QString&);
     void askForReadFromFile(const QString&);
     void askForSaveCurrentNetwork();
     void askForWriteDataToFile(const QString&);

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -52,6 +52,7 @@ private slots:
     void displayNullFeatureMenu();
     void displayFeatureMenu(QWidget* featureMenu);
     void removeFeatureMenu();
+    void deleteFeatureMenu();
 
 protected:
 
@@ -70,6 +71,7 @@ protected:
     QWidget* _featureMenu;
     QWidget* _statusBar;
     qreal _layoutMenuRow;
+    bool _canDisplayFeatureMenu;
 };
 
 #endif

--- a/src/negui_menu_button_manager.cpp
+++ b/src/negui_menu_button_manager.cpp
@@ -1,0 +1,34 @@
+#include "negui_menu_button_manager.h"
+#include "negui_menu_button_builder.h"
+#include "negui_node_style_builder.h"
+#include "negui_edge_style_builder.h"
+
+MyMenuButtonManager::MyMenuButtonManager() {
+
+}
+
+QList<QAbstractButton*> MyMenuButtonManager::getToolbarMenuButtons(QObject* interactor, QObject* undoStack, QList<MyPluginItemBase*> plugins, const QString& iconsDirectoryPath) {
+    return createToolbarMenuButtons(interactor, undoStack, plugins, iconsDirectoryPath);
+}
+
+QList<QAbstractButton*> MyMenuButtonManager::getModeMenuButtons(QObject* interactor, QList<MyPluginItemBase*> plugins, const QString& iconsDirectoryPath) {
+    addDefaultNodeStyle(plugins);
+    addDefaultEdgeStyle(plugins);
+    return createModeMenuButtons(interactor, plugins, iconsDirectoryPath);
+}
+
+void MyMenuButtonManager::addDefaultNodeStyle(QList<MyPluginItemBase*> plugins) {
+    if (!getPluginsOfType(plugins, "nodestyle").size()) {
+        QJsonObject styleObject;
+        styleObject["name"] = "Default";
+        askForAddPluginItem(createNodeStyle(styleObject));
+    }
+}
+
+void MyMenuButtonManager::addDefaultEdgeStyle(QList<MyPluginItemBase*> plugins) {
+    if (!getPluginsOfType(plugins, "edgestyle").size()) {
+        QJsonObject styleObject;
+        styleObject["name"] = "Default";
+        askForAddPluginItem(createEdgeStyle(styleObject));
+    }
+}

--- a/src/negui_menu_button_manager.cpp
+++ b/src/negui_menu_button_manager.cpp
@@ -1,7 +1,5 @@
 #include "negui_menu_button_manager.h"
 #include "negui_menu_button_builder.h"
-#include "negui_node_style_builder.h"
-#include "negui_edge_style_builder.h"
 
 MyMenuButtonManager::MyMenuButtonManager() {
 
@@ -12,23 +10,5 @@ QList<QAbstractButton*> MyMenuButtonManager::getToolbarMenuButtons(QObject* inte
 }
 
 QList<QAbstractButton*> MyMenuButtonManager::getModeMenuButtons(QObject* interactor, QList<MyPluginItemBase*> plugins, const QString& iconsDirectoryPath) {
-    addDefaultNodeStyle(plugins);
-    addDefaultEdgeStyle(plugins);
     return createModeMenuButtons(interactor, plugins, iconsDirectoryPath);
-}
-
-void MyMenuButtonManager::addDefaultNodeStyle(QList<MyPluginItemBase*> plugins) {
-    if (!getPluginsOfType(plugins, "nodestyle").size()) {
-        QJsonObject styleObject;
-        styleObject["name"] = "Default";
-        askForAddPluginItem(createNodeStyle(styleObject));
-    }
-}
-
-void MyMenuButtonManager::addDefaultEdgeStyle(QList<MyPluginItemBase*> plugins) {
-    if (!getPluginsOfType(plugins, "edgestyle").size()) {
-        QJsonObject styleObject;
-        styleObject["name"] = "Default";
-        askForAddPluginItem(createEdgeStyle(styleObject));
-    }
 }

--- a/src/negui_menu_button_manager.h
+++ b/src/negui_menu_button_manager.h
@@ -1,0 +1,29 @@
+#ifndef __NEGUI_MENU_BUTTON_MANAGER_H
+#define __NEGUI_MENU_BUTTON_MANAGER_H
+
+#include <QObject>
+#include <QAbstractButton>
+
+#include "negui_plugin_item_base.h"
+
+class MyMenuButtonManager : public QObject {
+    Q_OBJECT
+
+public:
+
+    MyMenuButtonManager();
+
+    QList<QAbstractButton*> getToolbarMenuButtons(QObject* interactor, QObject* undoStack, QList<MyPluginItemBase*> plugins, const QString& iconsDirectoryPath);
+
+    QList<QAbstractButton*> getModeMenuButtons(QObject* interactor, QList<MyPluginItemBase*> plugins, const QString& iconsDirectoryPath);
+
+    void addDefaultNodeStyle(QList<MyPluginItemBase*> plugins);
+
+    void addDefaultEdgeStyle(QList<MyPluginItemBase*> plugins);
+
+signals:
+
+    void askForAddPluginItem(MyPluginItemBase*);
+};
+
+#endif

--- a/src/negui_menu_button_manager.h
+++ b/src/negui_menu_button_manager.h
@@ -16,14 +16,6 @@ public:
     QList<QAbstractButton*> getToolbarMenuButtons(QObject* interactor, QObject* undoStack, QList<MyPluginItemBase*> plugins, const QString& iconsDirectoryPath);
 
     QList<QAbstractButton*> getModeMenuButtons(QObject* interactor, QList<MyPluginItemBase*> plugins, const QString& iconsDirectoryPath);
-
-    void addDefaultNodeStyle(QList<MyPluginItemBase*> plugins);
-
-    void addDefaultEdgeStyle(QList<MyPluginItemBase*> plugins);
-
-signals:
-
-    void askForAddPluginItem(MyPluginItemBase*);
 };
 
 #endif

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -34,7 +34,8 @@ void MyNetworkElementBase::updateFocusedGraphicsItems() {
 void MyNetworkElementBase::connectGraphicsItem() {
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForDeleteNetworkElement, this, [this] () { emit askForDeleteNetworkElement(this); });
     connect(_graphicsItem, SIGNAL(askForWhetherNetworkElementIsSelected()), this, SLOT(isSelected()));
-    connect(_graphicsItem, SIGNAL(askForCreateFeatureMenu()), this, SLOT(createFeatureMenu()));
+    connect(_graphicsItem, SIGNAL(askForEnableFeatureMenuDisplay()), this, SIGNAL(askForEnableFeatureMenuDisplay()));
+    connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForDisplayFeatureMenu, this, [this] () { emit askForDisplayFeatureMenu(this); });
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForCopyNetworkElement, this, [this] () { emit askForCopyNetworkElement(this); } );
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForCutNetworkElement, this, [this] () { emit askForCutNetworkElement(this); } );
     connect(_graphicsItem, &MyNetworkElementGraphicsItemBase::askForCopyNetworkElementStyle, this, [this] () { emit askForCopyNetworkElementStyle(this->style()); } );
@@ -43,7 +44,6 @@ void MyNetworkElementBase::connectGraphicsItem() {
     connect(_graphicsItem, SIGNAL(askForWhetherElementStyleIsCopied()), this, SIGNAL(askForWhetherElementStyleIsCopied()));
     connect(_graphicsItem, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
     connect(_graphicsItem, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
-    connect(_graphicsItem, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
 }
 
 MyNetworkElementStyleBase* MyNetworkElementBase::style() {
@@ -166,19 +166,7 @@ void MyNetworkElementBase::addAddRemoveShapeStyleButtonsToFeatureMenu(QWidget* f
     contentLayout->addWidget(shapeStylesButtons, contentLayout->rowCount(), 0, 1, 2, Qt::AlignRight);
 }
 
-void MyNetworkElementBase::createFeatureMenu() {
-    if (getSceneMode() == NORMAL_MODE) {
-        QWidget* currentFeatureMenu = askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
-        if (!currentFeatureMenu || currentFeatureMenu->objectName() != name()) {
-            QWidget* featureMenu = createAndConnectFeatureMenuObject();
-            if (currentFeatureMenu && ((MyFeatureMenuBase*)currentFeatureMenu)->type() == MyFeatureMenuBase::ELEMENT_FEATURE_MENU)
-                ((MyElementFeatureMenu*)featureMenu)->setBeingModifiedShapeStyle(((MyElementFeatureMenu*)currentFeatureMenu)->beingModifiedShapeStyle());
-            askForDisplayFeatureMenu(featureMenu);
-        }
-    }
-}
-
-QWidget* MyNetworkElementBase::createAndConnectFeatureMenuObject() {
+QWidget* MyNetworkElementBase::createFeatureMenu() {
     MyFeatureMenuBase* featureMenu =  new MyElementFeatureMenu(getFeatureMenu(), askForIconsDirectoryPath());
     featureMenu->setObjectName(name());
     ((MyElementFeatureMenu*)featureMenu)->setShapeStyles(style()->shapeStyles());

--- a/src/negui_network_element_base.cpp
+++ b/src/negui_network_element_base.cpp
@@ -175,6 +175,9 @@ QWidget* MyNetworkElementBase::createFeatureMenu() {
         updateGraphicsItem();
         updateFocusedGraphicsItems();
         emit askForCreateChangeStageCommand(); } );
+    QWidget* currentlyBeingDisplayedFeatureMenu = askForCurrentlyBeingDisplayedFeatureMenu();
+    if (currentlyBeingDisplayedFeatureMenu && ((MyFeatureMenuBase*)currentlyBeingDisplayedFeatureMenu)->type() == MyFeatureMenuBase::ELEMENT_FEATURE_MENU)
+        ((MyElementFeatureMenu*)featureMenu)->setBeingModifiedShapeStyle(((MyElementFeatureMenu*)currentlyBeingDisplayedFeatureMenu)->beingModifiedShapeStyle());
 
     return featureMenu;
 

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -77,7 +77,7 @@ public:
 
     virtual const qint32 calculateZValue() = 0;
 
-    QWidget* createAndConnectFeatureMenuObject();
+    QWidget* createFeatureMenu();
 
 signals:
     
@@ -89,9 +89,9 @@ signals:
     
     void askForCreateChangeStageCommand();
 
-    void askForDisplayFeatureMenu(QWidget*);
+    void askForEnableFeatureMenuDisplay();
 
-    QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
+    void askForDisplayFeatureMenu(MyNetworkElementBase*);
 
     void askForCopyNetworkElement(MyNetworkElementBase*);
 
@@ -120,8 +120,6 @@ public slots:
     virtual void setSelected(const bool& selected);
 
     const bool isSelected();
-
-    void createFeatureMenu();
     
 protected slots:
 

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -91,6 +91,8 @@ signals:
 
     void askForEnableFeatureMenuDisplay();
 
+    QWidget* askForCurrentlyBeingDisplayedFeatureMenu();
+
     void askForDisplayFeatureMenu(MyNetworkElementBase*);
 
     void askForCopyNetworkElement(MyNetworkElementBase*);

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -103,13 +103,13 @@ signals:
 
     void askForDeleteNetworkElement(MyNetworkElementBase*);
 
-    const bool askForWhetherElementStyleIsCopied();
+    bool askForWhetherElementStyleIsCopied();
 
     const bool askForWhetherAnyOtherElementsAreSelected(QList<MyNetworkElementBase*>);
 
     const QString askForIconsDirectoryPath();
 
-    const bool askForCheckWhetherNetworkElementNameIsAlreadyUsed(const QString&);
+    bool askForCheckWhetherNetworkElementNameIsAlreadyUsed(const QString&);
 
     void askForDisplaySceneContextMenu(const QPointF&);
 

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -105,7 +105,7 @@ signals:
 
     bool askForWhetherElementStyleIsCopied();
 
-    const bool askForWhetherAnyOtherElementsAreSelected(QList<MyNetworkElementBase*>);
+    bool askForWhetherAnyOtherElementsAreSelected(QList<MyNetworkElementBase*>);
 
     const QString askForIconsDirectoryPath();
 

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -10,11 +10,7 @@ MyNetworkElementGraphicsItemBase::MyNetworkElementGraphicsItemBase(QGraphicsItem
     _isChosen = false;
     _originalPosition = QPointF(0.0, 0.0);
     connect(this, SIGNAL(mouseLeftButtonIsPressed()), this, SIGNAL(askForSelectNetworkElement()));
-    connect(this, SIGNAL(mouseLeftButtonIsDoubleClicked()), this, SIGNAL(askForCreateFeatureMenu()));
-    connect(this, &MyNetworkElementGraphicsItemBase::mouseLeftButtonIsPressed, this, [this] () {
-        if (askForCurrentlyBeingDisplayedNetworkElementFeatureMenu())
-            askForCreateFeatureMenu();
-    });
+    connect(this, SIGNAL(mouseLeftButtonIsDoubleClicked()), this, SIGNAL(askForEnableFeatureMenuDisplay()));
 }
 
 void MyNetworkElementGraphicsItemBase::update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) {
@@ -103,7 +99,7 @@ const bool MyNetworkElementGraphicsItemBase::canAddLineShape() {
 }
 
 void MyNetworkElementGraphicsItemBase::connectContextMenu(QMenu* contextMenu) {
-    connect(contextMenu, SIGNAL(askForCreateFeatureMenu()), this, SIGNAL(askForCreateFeatureMenu()));
+    connect(contextMenu, SIGNAL(askForDisplayFeatureMenu()), this, SIGNAL(askForDisplayFeatureMenu()));
     connect(contextMenu, SIGNAL(askForCopyNetworkElement()), this, SIGNAL(askForCopyNetworkElement()));
     connect(contextMenu, SIGNAL(askForCutNetworkElement()), this, SIGNAL(askForCutNetworkElement()));
     connect(contextMenu, SIGNAL(askForCopyNetworkElementStyle()), this, SIGNAL(askForCopyNetworkElementStyle()));

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -73,7 +73,7 @@ signals:
     void askForRemoveGraphicsItem(QGraphicsItem*);
     void askForCreateChangeStageCommand();
     void askForClearFocusedGraphicsItems();
-    void askForCreateFeatureMenu();
+    void askForEnableFeatureMenuDisplay();
     void askForCopyNetworkElement();
     void askForCutNetworkElement();
     void askForCopyNetworkElementStyle();
@@ -82,8 +82,8 @@ signals:
     bool askForWhetherElementStyleIsCopied();
     const bool askForWhetherAnyOtherElementsAreSelected();
     QString askForDisplayName();
+    void askForDisplayFeatureMenu();
     void askForDisplaySceneContextMenu(const QPointF&);
-    QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
 
 public slots:
 

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -79,7 +79,7 @@ signals:
     void askForCopyNetworkElementStyle();
     void askForPasteNetworkElementStyle();
     void askForDeleteNetworkElement();
-    const bool askForWhetherElementStyleIsCopied();
+    bool askForWhetherElementStyleIsCopied();
     const bool askForWhetherAnyOtherElementsAreSelected();
     QString askForDisplayName();
     void askForDisplaySceneContextMenu(const QPointF&);

--- a/src/negui_network_element_selector.cpp
+++ b/src/negui_network_element_selector.cpp
@@ -36,10 +36,8 @@ void MyNetworkElementSelector::setElementSelected(MyNetworkElementBase* networkE
 }
 
 void MyNetworkElementSelector::selectElement(MyNetworkElementBase* networkElement, const bool& selected) {
-    if (networkElement->isSelected() != selected) {
+    if (networkElement->isSelected() != selected)
         networkElement->setSelected(selected);
-        emit networkElementsSelectedStatusIsChanged();
-    }
 }
 
 void MyNetworkElementSelector::changeElementSelectionsStatus(MyNetworkElementBase* networkElement) {
@@ -57,7 +55,6 @@ void MyNetworkElementSelector::changeElementSelectionsStatus(MyNetworkElementBas
                 selectElements(false);
             selectElement(networkElement, true);
         }
-        emit networkElementsSelectedStatusIsChanged();
     }
 }
 
@@ -203,7 +200,6 @@ void MyNetworkElementSelector::clearSelectionArea() {
             selectElements(false);
         selectSelectionAreaCoveredNodes();
         selectSelectionAreaCoveredEdges();
-        emit networkElementsSelectedStatusIsChanged();
 
         askForRemoveGraphicsItem(_selectionAreaGraphicsItem);
         delete _selectionAreaGraphicsItem;

--- a/src/negui_network_element_selector.cpp
+++ b/src/negui_network_element_selector.cpp
@@ -160,19 +160,9 @@ MyNetworkElementBase* MyNetworkElementSelector::getOneSingleSelectedEdge() {
     return NULL;
 }
 
-const bool MyNetworkElementSelector::canDisplaySingleElementFeatureMenu() {
-    return !askForWhetherShiftModifierIsPressed() || getOneSingleSelectedNode() || getOneSingleSelectedEdge();
-}
-
 void MyNetworkElementSelector::displaySelectionArea(const QPointF& position) {
-    if (getSceneMode() == NORMAL_MODE) {
-        if (!askForWhetherShiftModifierIsPressed())
-            selectElements(false);
+    if (getSceneMode() == NORMAL_MODE)
         createSelectionAreaGraphicsItem(position);
-        selectSelectionAreaCoveredNodes();
-        selectSelectionAreaCoveredEdges();
-        emit networkElementsSelectedStatusIsChanged();
-    }
 }
 
 void MyNetworkElementSelector::createSelectionAreaGraphicsItem(const QPointF& position) {
@@ -209,6 +199,12 @@ void MyNetworkElementSelector::setCollidingElementsSelected(QList<MyNetworkEleme
 
 void MyNetworkElementSelector::clearSelectionArea() {
     if (_selectionAreaGraphicsItem) {
+        if (!askForWhetherShiftModifierIsPressed())
+            selectElements(false);
+        selectSelectionAreaCoveredNodes();
+        selectSelectionAreaCoveredEdges();
+        emit networkElementsSelectedStatusIsChanged();
+
         askForRemoveGraphicsItem(_selectionAreaGraphicsItem);
         delete _selectionAreaGraphicsItem;
         _selectionAreaGraphicsItem = NULL;

--- a/src/negui_network_element_selector.h
+++ b/src/negui_network_element_selector.h
@@ -74,8 +74,6 @@ signals:
 
     QList<MyNetworkElementBase*> askForEdges();
 
-    void networkElementsSelectedStatusIsChanged();
-
     const bool askForWhetherShiftModifierIsPressed();
 
     void askForAddGraphicsItem(QGraphicsItem*);

--- a/src/negui_network_element_selector.h
+++ b/src/negui_network_element_selector.h
@@ -54,8 +54,6 @@ public:
 
     MyNetworkElementBase* getOneSingleSelectedEdge();
 
-    const bool canDisplaySingleElementFeatureMenu();
-
     void displaySelectionArea(const QPointF& position);
 
     void createSelectionAreaGraphicsItem(const QPointF& position);

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -16,6 +16,11 @@
 MyNetworkManager::MyNetworkManager() {
     _newEdgeBuilder = NULL;
     setNetworkElementSelector();
+    connect(this, &MyNetworkManager::networkElementsSelectedStatusIsChanged, this, [this] () {
+        emit elementsCuttableStatusChanged(areSelectedElementsCuttable());
+        emit elementsCopyableStatusChanged(areSelectedElementsCopyable());
+        updateFeatureMenu();
+    });
     resetNetwork();
 }
 
@@ -245,17 +250,13 @@ void MyNetworkManager::setNetworkElementSelector() {
     connect(_networkElementSelector, SIGNAL(askForWhetherShiftModifierIsPressed()), this, SIGNAL(askForWhetherShiftModifierIsPressed()));
     connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::askForNodes, this, [this] () { return nodes(); });
     connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::askForEdges, this, [this] () { return edges(); });
-    connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::networkElementsSelectedStatusIsChanged, this, [this] () {
-        emit elementsCuttableStatusChanged(areSelectedElementsCuttable());
-        emit elementsCopyableStatusChanged(areSelectedElementsCopyable());
-        updateFeatureMenu();
-    });
     connect(_networkElementSelector, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
     connect(_networkElementSelector, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
 }
 
 void MyNetworkManager::changeElementSelectionsStatus(MyNetworkElementBase* element) {
     ((MyNetworkElementSelector*)_networkElementSelector)->changeElementSelectionsStatus(element);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 const bool MyNetworkManager::areSelectedElementsCopyable() {
@@ -382,6 +383,7 @@ void MyNetworkManager::addNode(MyNetworkElementBase* n) {
         connect(n, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
         connect(n, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
         connect(n, SIGNAL(askForEnableFeatureMenuDisplay()), this, SIGNAL(askForEnableFeatureMenuDisplay()));
+        connect(n, SIGNAL(askForCurrentlyBeingDisplayedFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedFeatureMenu()));
         connect(n, &MyNetworkElementBase::askForDisplayFeatureMenu, this, [this] (MyNetworkElementBase* networkElement) {
             selectElements(false);
             setElementSelected(networkElement->name());
@@ -458,6 +460,7 @@ void MyNetworkManager::addEdge(MyNetworkElementBase* e) {
         connect(e, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
         connect(e, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
         connect(e, SIGNAL(askForEnableFeatureMenuDisplay()), this, SIGNAL(askForEnableFeatureMenuDisplay()));
+        connect(e, SIGNAL(askForCurrentlyBeingDisplayedFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedFeatureMenu()));
         connect(e, &MyNetworkElementBase::askForDisplayFeatureMenu, this, [this] (MyNetworkElementBase* networkElement) {
             selectElements(false);
             setElementSelected(networkElement->name());
@@ -625,30 +628,37 @@ QJsonObject MyNetworkManager::exportNetworkInfo() {
 
 void MyNetworkManager::selectElements(const bool& selected) {
     ((MyNetworkElementSelector*)_networkElementSelector)->selectElements(selected);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 void MyNetworkManager::selectElementsOfCategory(const bool& selected, const QString& category) {
     ((MyNetworkElementSelector*)_networkElementSelector)->selectElementsOfCategory(category, selected);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 void MyNetworkManager::selectNodes(const bool& selected) {
     ((MyNetworkElementSelector*)_networkElementSelector)->selectNodes(selected);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 void MyNetworkManager::selectNodesOfCategory(const bool& selected, const QString& category) {
     ((MyNetworkElementSelector*)_networkElementSelector)->selectNodesOfCategory(category, selected);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 void MyNetworkManager::selectEdges(const bool& selected) {
     ((MyNetworkElementSelector*)_networkElementSelector)->selectEdges(selected);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 void MyNetworkManager::selectEdgesOfCategory(const bool& selected, const QString& category) {
     ((MyNetworkElementSelector*)_networkElementSelector)->selectEdgesOfCategory(category, selected);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 void MyNetworkManager::setElementSelected(const QString& elementName) {
     ((MyNetworkElementSelector*)_networkElementSelector)->setElementSelected(elementName);
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 MyNetworkElementBase* MyNetworkManager::getOneSingleSelectedElement() {
@@ -681,6 +691,7 @@ void MyNetworkManager::selectSelectionAreaCoveredEdges() {
 
 void MyNetworkManager::clearSelectionArea() {
     ((MyNetworkElementSelector*)_networkElementSelector)->clearSelectionArea();
+    emit networkElementsSelectedStatusIsChanged();
 }
 
 void MyNetworkManager::updateFeatureMenu() {

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -27,8 +27,8 @@ void MyNetworkManager::enableNormalMode() {
     setCopiedNodeStyle(NULL);
     setEdgeStyle(NULL);
     setCopiedEdgeStyle(NULL);
-    deleteNewEdgeBuilder();
     ((MyNetworkElementSelector*)_networkElementSelector)->enableNormalMode();
+    deleteNewEdgeBuilder();
     for (MyNetworkElementBase *node : qAsConst(nodes()))
         node->enableNormalMode();
     for (MyNetworkElementBase *edge : qAsConst(edges()))
@@ -561,8 +561,7 @@ bool MyNetworkManager::isElementNameAlreadyUsed(const QString& elementName) {
 }
 
 void MyNetworkManager::deleteNewEdgeBuilder() {
-    for (MyNetworkElementBase* selectedNode : getSelectedNodes())
-        selectedNode->setSelected(false);
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectNodes(false);
     if (_newEdgeBuilder)
         _newEdgeBuilder->deleteLater();
     _newEdgeBuilder = NULL;

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -1,0 +1,685 @@
+#include "negui_network_manager.h"
+#include "negui_new_edge_builder.h"
+#include "negui_copied_network_elements_paster.h"
+#include "negui_network_element_selector.h"
+#include "negui_network_element_mover.h"
+#include "negui_node.h"
+#include "negui_node_builder.h"
+#include "negui_edge.h"
+#include "negui_edge_builder.h"
+#include "negui_network_element_aligner.h"
+#include "negui_network_element_aligner_builder.h"
+
+#include <QJsonArray>
+
+MyNetworkManager::MyNetworkManager() {
+    _newEdgeBuilder = NULL;
+    setNetworkElementSelector();
+}
+
+void MyNetworkManager::enableNormalMode() {
+    MySceneModeElementBase::enableNormalMode();
+    resetCopiedNetworkElements();
+    setCopiedNode(NULL);
+    setNodeStyle(NULL);
+    setCopiedNodeStyle(NULL);
+    setEdgeStyle(NULL);
+    setCopiedEdgeStyle(NULL);
+    deleteNewEdgeBuilder();
+    ((MyNetworkElementSelector*)_networkElementSelector)->enableNormalMode();
+    for (MyNetworkElementBase *node : qAsConst(nodes()))
+        node->enableNormalMode();
+    for (MyNetworkElementBase *edge : qAsConst(edges()))
+        edge->enableNormalMode();
+}
+
+void MyNetworkManager::enableAddNodeMode(MyNetworkElementStyleBase* style) {
+    MySceneModeElementBase::enableAddNodeMode();
+    setNodeStyle(style);
+    ((MyNetworkElementSelector*)_networkElementSelector)->enableAddNodeMode();
+    for (MyNetworkElementBase *node : qAsConst(nodes()))
+        node->enableAddNodeMode();
+    for (MyNetworkElementBase *edge : qAsConst(edges()))
+        edge->enableAddNodeMode();
+}
+
+void MyNetworkManager::enableAddEdgeMode(MyNetworkElementStyleBase* style) {
+    MySceneModeElementBase::enableAddEdgeMode();
+    setEdgeStyle(style);
+    ((MyNetworkElementSelector*)_networkElementSelector)->enableAddEdgeMode();
+    for (MyNetworkElementBase *node : qAsConst(nodes()))
+        node->enableAddEdgeMode();
+    for (MyNetworkElementBase *edge : qAsConst(edges()))
+        edge->enableAddEdgeMode();
+}
+
+void MyNetworkManager::enableSelectMode() {
+    MySceneModeElementBase::enableSelectMode();
+    ((MyNetworkElementSelector*)_networkElementSelector)->enableSelectMode();
+    for (MyNetworkElementBase *node : qAsConst(nodes()))
+        node->enableSelectNodeMode();
+    for (MyNetworkElementBase *edge : qAsConst(edges()))
+        edge->enableSelectEdgeMode();
+}
+
+void MyNetworkManager::enableSelectNodeMode() {
+    enableNormalMode();
+    MySceneModeElementBase::enableSelectNodeMode();
+    ((MyNetworkElementSelector*)_networkElementSelector)->enableSelectNodeMode();
+    for (MyNetworkElementBase *node : qAsConst(nodes()))
+        node->enableSelectNodeMode();
+    for (MyNetworkElementBase *edge : qAsConst(edges()))
+        edge->enableSelectNodeMode();
+}
+
+void MyNetworkManager::enableSelectEdgeMode() {
+    enableNormalMode();
+    MySceneModeElementBase::enableSelectEdgeMode();
+    ((MyNetworkElementSelector*)_networkElementSelector)->enableSelectEdgeMode();
+    for (MyNetworkElementBase *node : qAsConst(nodes()))
+        node->enableSelectEdgeMode();
+    for (MyNetworkElementBase *edge : qAsConst(edges()))
+        edge->enableSelectEdgeMode();
+}
+
+QList<MyNetworkElementBase*>& MyNetworkManager::nodes() {
+    return _nodes;
+}
+
+QList<MyNetworkElementBase*>& MyNetworkManager::edges() {
+    return _edges;
+}
+
+void MyNetworkManager::clearNodesInfo() {
+    while(nodes().size())
+        delete nodes().takeLast();
+}
+
+void MyNetworkManager::clearEdgesInfo() {
+    while(edges().size())
+        delete edges().takeLast();
+}
+
+MyNetworkElementStyleBase* MyNetworkManager::nodeStyle() {
+    return _nodeStyle;
+}
+
+void MyNetworkManager::setNodeStyle(MyNetworkElementStyleBase* style) {
+    if (style)
+        _nodeStyle = style;
+    else
+        _nodeStyle = NULL;
+}
+
+void MyNetworkManager::setCopiedNodeStyle(MyNetworkElementStyleBase* style) {
+    if (style)
+        _copiedNodeStyle = style;
+    else
+        _copiedNodeStyle = NULL;
+}
+
+MyNetworkElementStyleBase* MyNetworkManager::copiedNodeStyle() {
+    return _copiedNodeStyle;
+}
+
+bool MyNetworkManager::isSetCopiedNodeStyle() {
+    if (_copiedNodeStyle)
+        return true;
+
+    return false;
+}
+
+void MyNetworkManager::pasteCopiedNodeStyle(MyNetworkElementBase* element) {
+    element->updateStyle(getCopyNodeStyle(element->style()->name(), _copiedNodeStyle)->shapeStyles());
+    element->updateGraphicsItem();
+    askForCreateChangeStageCommand();
+}
+
+MyNetworkElementStyleBase* MyNetworkManager::edgeStyle() {
+    return _edgeStyle;
+}
+
+void MyNetworkManager::setEdgeStyle(MyNetworkElementStyleBase* style) {
+    if (style)
+        _edgeStyle = style;
+    else
+        _edgeStyle = NULL;
+}
+
+void MyNetworkManager::setCopiedEdgeStyle(MyNetworkElementStyleBase* style) {
+    if (style)
+        _copiedEdgeStyle = style;
+    else
+        _copiedEdgeStyle = NULL;
+}
+
+MyNetworkElementStyleBase* MyNetworkManager::copiedEdgeStyle() {
+    return _copiedEdgeStyle;
+}
+
+const bool MyNetworkManager::isSetCopiedEdgeStyle() {
+    if (_copiedEdgeStyle)
+        return true;
+
+    return false;
+}
+
+void MyNetworkManager::pasteCopiedEdgeStyle(MyNetworkElementBase* element) {
+    element->updateStyle(getCopyEdgeStyle(element->style()->name(), _copiedEdgeStyle)->shapeStyles());
+    element->updateGraphicsItem();
+    askForCreateChangeStageCommand();
+}
+
+void MyNetworkManager::setCutNode(MyNetworkElementBase* node) {
+    setCopiedNode(node);
+    removeNode(node);
+}
+
+void MyNetworkManager::setCopiedNode(MyNetworkElementBase* node) {
+    resetCopiedNetworkElements();
+    if (node)
+        _copiedNetworkElements.push_back(node);
+}
+
+QList<MyNetworkElementBase*> MyNetworkManager::copiedNetworkElements() {
+    return _copiedNetworkElements;
+}
+
+const bool MyNetworkManager::areAnyElementsSelected() {
+    if (getSelectedNodes().size() || getSelectedEdges().size())
+        return true;
+
+    return false;
+}
+
+void MyNetworkManager::copySelectedNetworkElements() {
+    resetCopiedNetworkElements();
+    for (MyNetworkElementBase* selectedElement : getSelectedElements()) {
+        if (!selectedElement->isCopyable())
+            return;
+    }
+
+    for (MyNetworkElementBase* selectedNode : getSelectedNodes())
+        _copiedNetworkElements.push_back(selectedNode);
+    for (MyNetworkElementBase* selectedEdge : getSelectedEdges())
+        _copiedNetworkElements.push_back(selectedEdge);
+    if (_copiedNetworkElements.size())
+        emit pasteElementsStatusChanged(true);
+}
+
+void MyNetworkManager::cutSelectedNetworkElements() {
+    copySelectedNetworkElements();
+    if (copiedNetworkElements().size()) {
+        for (MyNetworkElementBase* selectedEdge : getSelectedEdges())
+            removeEdge(selectedEdge);
+        for (MyNetworkElementBase* selectedNode : getSelectedNodes())
+            removeNode(selectedNode);
+    }
+}
+
+void MyNetworkManager::pasteCopiedNetworkElements() {
+    pasteCopiedNetworkElements(askForItemsBoundingRect().center());
+}
+
+void MyNetworkManager::pasteCopiedNetworkElements(const QPointF& position) {
+    MyCopiedNetworkElementsPaster* copiedNetworkElementsPaster = new MyCopiedNetworkElementsPaster(copiedNetworkElements(), position);
+    connect(copiedNetworkElementsPaster, &MyCopiedNetworkElementsPaster::askForAddNode, this, [this] (MyNetworkElementBase* node) { this->addNode(node); });
+    connect(copiedNetworkElementsPaster, &MyCopiedNetworkElementsPaster::askForNodeUniqueName, this, [this] (MyNetworkElementStyleBase* nodeStyle) { return getElementUniqueName(this->nodes(), nodeStyle->category()); });
+    connect(copiedNetworkElementsPaster, &MyCopiedNetworkElementsPaster::askForAddEdge, this, [this] (MyNetworkElementBase* edge) { this->addEdge(edge); });
+    connect(copiedNetworkElementsPaster, &MyCopiedNetworkElementsPaster::askForEdgeUniqueName, this, [this] (MyNetworkElementStyleBase* edgeStyle) { return getElementUniqueName(this->edges(), edgeStyle->category()); });
+    copiedNetworkElementsPaster->paste();
+    copiedNetworkElementsPaster->deleteLater();
+    askForCreateChangeStageCommand();
+}
+
+
+void MyNetworkManager::resetCopiedNetworkElements() {
+    _copiedNetworkElements.clear();
+    emit pasteElementsStatusChanged(false);
+}
+
+void MyNetworkManager::setNetworkElementSelector() {
+    _networkElementSelector = new MyNetworkElementSelector();
+    connect(_networkElementSelector, SIGNAL(askForWhetherShiftModifierIsPressed()), this, SIGNAL(askForWhetherShiftModifierIsPressed()));
+    connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::askForNodes, this, [this] () { return nodes(); });
+    connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::askForEdges, this, [this] () { return edges(); });
+    connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::networkElementsSelectedStatusIsChanged, this, [this] () {
+        emit elementsCuttableStatusChanged(areSelectedElementsCuttable());
+        emit elementsCopyableStatusChanged(areSelectedElementsCopyable());
+    });
+    connect(this, &MyNetworkManager::singleNetworkElementFeatureMenuIsDisplayed, this, [this] (const QString& elementName) {
+        ((MyNetworkElementSelector*)_networkElementSelector)->selectElements(false);
+        ((MyNetworkElementSelector*)_networkElementSelector)->setElementSelected(elementName);
+    });
+    connect(this, &MyNetworkManager::multiNetworkElementFeatureMenuIsDisplayed, this, [this] (const QString& elementName) {
+        ((MyNetworkElementSelector *) _networkElementSelector)->setElementSelected(elementName);
+    });
+    connect(_networkElementSelector, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
+    connect(_networkElementSelector, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
+}
+
+void MyNetworkManager::changeElementSelectionsStatus(MyNetworkElementBase* element) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->changeElementSelectionsStatus(element);
+}
+
+const bool MyNetworkManager::areSelectedElementsCopyable() {
+    if (getSelectedNodes().size() || getSelectedEdges().size()) {
+        for (MyNetworkElementBase* selectedNode : getSelectedNodes()) {
+            if (!selectedNode->isCopyable())
+                return false;
+        }
+        for (MyNetworkElementBase* selectedEdge : getSelectedEdges()) {
+            if (!selectedEdge->isCopyable())
+                return false;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+const bool MyNetworkManager::areSelectedElementsCuttable() {
+    if (getSelectedNodes().size() || getSelectedEdges().size()) {
+        for (MyNetworkElementBase* selectedNode : getSelectedNodes()) {
+            if (!selectedNode->isCuttable())
+                return false;
+        }
+        for (MyNetworkElementBase* selectedEdge : getSelectedEdges()) {
+            if (!selectedEdge->isCuttable())
+                return false;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+const bool MyNetworkManager::areSelectedElementsAlignable() {
+    if (getSelectedNodes().size() > 1)
+        return true;
+
+    return false;
+}
+
+const bool MyNetworkManager::areAnyElementsCopied() {
+    if (copiedNetworkElements().size())
+        return true;
+
+    return false;
+}
+
+const QList<MyNetworkElementBase*> MyNetworkManager::getSelectedElements() {
+    return ((MyNetworkElementSelector*)_networkElementSelector)->getSelectedElements();
+}
+
+const QList<MyNetworkElementBase*> MyNetworkManager::getSelectedNodes() {
+    return ((MyNetworkElementSelector*)_networkElementSelector)->getSelectedNodes();
+}
+
+const QList<MyNetworkElementBase*> MyNetworkManager::getSelectedEdges() {
+    return ((MyNetworkElementSelector*)_networkElementSelector)->getSelectedEdges();
+}
+
+void MyNetworkManager::createNetwork(const QJsonObject& json) {
+    resetNetwork();
+    setBackground(json);
+    addNodes(json);
+    addEdges(json);
+}
+
+void MyNetworkManager::resetNetworkCanvas() {
+    resetNetwork();
+    resetCanvas();
+}
+
+void MyNetworkManager::resetNetwork() {
+    clearNodesInfo();
+    clearEdgesInfo();
+    emit askForClearScene();
+}
+
+void MyNetworkManager::resetCanvas() {
+    emit askForResetScale();
+    askForEnableNormalMode();
+    askForClearUndoStack();
+}
+
+void MyNetworkManager::setBackground(const QJsonObject &json) {
+    if (json.contains("background-color") && json["background-color"].isString())
+        askForSetNetworkBackgroundColor(json["background-color"].toString());
+}
+
+void MyNetworkManager::addNodes(const QJsonObject &json) {
+    if (json.contains("nodes") && json["nodes"].isArray()) {
+        QJsonArray nodesArray = json["nodes"].toArray();
+        for (int nodeIndex = 0; nodeIndex < nodesArray.size(); ++nodeIndex)
+            addNode(nodesArray[nodeIndex].toObject());
+        updateNodeParents();
+    }
+}
+
+void MyNetworkManager::addNode(const QJsonObject &json) {
+    MyNetworkElementBase* node = createNode(json);
+    if (node)
+        addNode(node);
+}
+
+void MyNetworkManager::addNewNode(const QPointF& position) {
+    if (getSceneMode() == ADD_NODE_MODE) {
+        MyNetworkElementBase* node = createNode(getElementUniqueName(nodes(), nodeStyle()->category()), getCopyNodeStyle(getElementUniqueName(nodes(), nodeStyle()->category()) + "_style", nodeStyle()), position.x(), position.y());
+        addNode(node);
+        askForCreateChangeStageCommand();
+    }
+}
+
+void MyNetworkManager::addNode(MyNetworkElementBase* n) {
+    if (n && !n->isActive()) {
+        _nodes.push_back(n);
+        n->setActive(true);
+        n->updateGraphicsItem();
+        connect(n, &MyNetworkElementBase::askForSelectNetworkElement, this, [this] (MyNetworkElementBase* networkElement) { changeElementSelectionsStatus(networkElement); });
+        connect(n, &MyNetworkElementBase::askForSelectNetworkElement, this, [this] (MyNetworkElementBase* networkElement) { addNewEdge(networkElement); });
+        connect(n, &MyNetworkElementBase::askForDeleteNetworkElement, this, [this] (MyNetworkElementBase* networkElement) { deleteNode(networkElement); });
+        connect(n, &MyNetworkElementBase::askForListOfElements, this, [this] () { return nodes() + edges(); } );
+        connect(n, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
+        connect(n, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
+        connect(n, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
+        connect(n, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
+        connect(n, &MyNetworkElementBase::askForCheckWhetherNetworkElementNameIsAlreadyUsed, this, [this] (const QString& elementName) { return isElementNameAlreadyUsed(elementName); });
+        connect(n, &MyNetworkElementBase::askForCopyNetworkElement, this, [this] (MyNetworkElementBase* networkElement) { setCopiedNode(networkElement); });
+        connect(n, &MyNetworkElementBase::askForCutNetworkElement, this, [this] (MyNetworkElementBase* networkElement) { setCutNode(networkElement); });
+        connect(n, &MyNetworkElementBase::askForCopyNetworkElementStyle, this, [this] (MyNetworkElementStyleBase* style) { setCopiedNodeStyle(style); });
+        connect(n, &MyNetworkElementBase::askForPasteNetworkElementStyle, this, [this] (MyNetworkElementBase* networkElement) { pasteCopiedNodeStyle(networkElement); });
+        connect(n, &MyNetworkElementBase::askForWhetherElementStyleIsCopied, this, [this] () { return isSetCopiedNodeStyle(); } );
+        connect(n, &MyNetworkElementBase::askForWhetherAnyOtherElementsAreSelected, this, [this] (QList<MyNetworkElementBase*> networkElements) {
+            ((MyNetworkElementSelector*)_networkElementSelector)->areAnyOtherElementsSelected(networkElements); });
+        connect(n, SIGNAL(askForIconsDirectoryPath()), this, SIGNAL(askForIconsDirectoryPath()));
+        connect(n, SIGNAL(positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&)), this, SLOT(moveSelectedNetworkElements(MyNetworkElementBase*, const QPointF&)));
+        connect(n, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
+        connect(n, SIGNAL(askForWhetherControlModifierIsPressed()), this, SIGNAL(askForWhetherControlModifierIsPressed()));
+        connect(n->graphicsItem(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
+        connect(n->graphicsItem(), SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
+        connect(this, SIGNAL(askForAdjustConnectedEdgesOfNodes()), n, SLOT(adjustConnectedEdges()));
+        connect(this, SIGNAL(askForAdjustExtentsOfNodes()), n, SLOT(adjustExtents()));
+        emit askForAddGraphicsItem(n->graphicsItem());
+    }
+}
+
+void MyNetworkManager::deleteNode(MyNetworkElementBase* node) {
+    for (MyNetworkElementBase *edge : qAsConst(((MyNodeBase*)node)->edges())) {
+        ((MyNodeBase*)node)->removeEdge(edge);
+        removeEdge(edge);
+    }
+    removeNode(node);
+    askForCreateChangeStageCommand();
+}
+
+void MyNetworkManager::removeNode(MyNetworkElementBase* n) {
+    if (n && n->isActive()) {
+        _nodes.removeOne(n);
+        n->setActive(false);
+        n->setSelected(false);
+        emit askForRemoveGraphicsItem(n->graphicsItem());
+    }
+}
+
+void MyNetworkManager::updateNodeParents() {
+    MyNetworkElementBase* parentNode = NULL;
+    for (MyNetworkElementBase *node : qAsConst(nodes())) {
+        parentNode = findElement(nodes(), ((MyNodeBase*)node)->parentNodeId());
+        if (parentNode)
+            ((MyNodeBase*)node)->setParentNode((MyNodeBase*)parentNode);
+    }
+}
+
+void MyNetworkManager::addEdges(const QJsonObject &json) {
+    if (json.contains("edges") && json["edges"].isArray()) {
+        QJsonArray edgesArray = json["edges"].toArray();
+        for (int edgeIndex = 0; edgeIndex < edgesArray.size(); ++edgeIndex)
+            addEdge(edgesArray[edgeIndex].toObject());
+    }
+}
+
+void MyNetworkManager::addEdge(const QJsonObject &json) {
+    MyNetworkElementBase* edge = createEdge(json, findSourceNode(nodes(), json), findTargetNode(nodes(), json));
+    if (edge)
+        addEdge(edge);
+}
+
+void MyNetworkManager::addEdge(MyNetworkElementBase* e) {
+    if (e && !edgeExists(((MyEdgeBase*)e)->sourceNode(), ((MyEdgeBase*)e)->targetNode()) && e->setActive(true)) {
+        _edges.push_back(e);
+        e->updateGraphicsItem();
+        connect(e, &MyNetworkElementBase::askForSelectNetworkElement, this, [this] (MyNetworkElementBase* networkElement) { changeElementSelectionsStatus(networkElement); });
+        connect(e, &MyNetworkElementBase::askForDeleteNetworkElement, this, [this] (MyNetworkElementBase* networkElement) { deleteEdge(networkElement); });
+        connect(e, &MyNetworkElementBase::askForListOfElements, this, [this] () { return nodes() + edges(); } );
+        connect(e, SIGNAL(askForItemsAtPosition(const QPointF&)), this, SIGNAL(askForItemsAtPosition(const QPointF&)));
+        connect(e, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
+        connect(e, SIGNAL(askForDisplayFeatureMenu(QWidget*)), this, SIGNAL(askForDisplayFeatureMenu(QWidget*)));
+        connect(e, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()), this, SIGNAL(askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()));
+        connect(e, &MyNetworkElementBase::askForCheckWhetherNetworkElementNameIsAlreadyUsed, this, [this] (const QString& elementName) { return isElementNameAlreadyUsed(elementName); });
+        connect(e, &MyNetworkElementBase::askForCopyNetworkElementStyle, this, [this] (MyNetworkElementStyleBase* style) { setCopiedEdgeStyle(style); });
+        connect(e, &MyNetworkElementBase::askForPasteNetworkElementStyle, this, [this] (MyNetworkElementBase* networkElement) { pasteCopiedEdgeStyle(networkElement); });
+        connect(e, &MyNetworkElementBase::askForWhetherAnyOtherElementsAreSelected, this, [this] (QList<MyNetworkElementBase*> networkElements) {
+            ((MyNetworkElementSelector*)_networkElementSelector)->areAnyOtherElementsSelected(networkElements); });
+        connect(e, &MyNetworkElementBase::askForWhetherElementStyleIsCopied, this, [this] () { return isSetCopiedEdgeStyle(); } );
+        connect(e, SIGNAL(askForIconsDirectoryPath()), this, SIGNAL(askForIconsDirectoryPath()));
+        connect(e->graphicsItem(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
+        connect(e->graphicsItem(), SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
+        emit askForAddGraphicsItem(e->graphicsItem());
+        if (((MyEdgeBase*)e)->isSetArrowHead())
+            emit askForAddGraphicsItem(((MyEdgeBase*)e)->arrowHead()->graphicsItem());
+    }
+}
+
+void MyNetworkManager::addNewEdge(MyNetworkElementBase* element) {
+    if (getSceneMode() == ADD_EDGE_MODE) {
+        if (!_newEdgeBuilder) {
+            if (edgeStyle()->type() == "templatestyle") {
+                _newEdgeBuilder = new MyNewTemplateBuilder(edgeStyle());
+                connect((MyNewTemplateBuilder*)_newEdgeBuilder, &MyNewTemplateBuilder::askForAddNode, this, [this] (MyNetworkElementBase* node) { this->addNode(node); });
+                connect((MyNewTemplateBuilder*)_newEdgeBuilder, &MyNewTemplateBuilder::askForNodeUniqueName, this, [this] (MyNetworkElementStyleBase* nodeStyle) { return getElementUniqueName(this->nodes(), nodeStyle->category()); });
+            }
+            else
+                _newEdgeBuilder = new MyNewEdgeBuilder(edgeStyle());
+            connect((MyNewEdgeBuilderBase*)_newEdgeBuilder, &MyNewEdgeBuilderBase::askForAddEdge, this, [this] (MyNetworkElementBase* edge) { this->addEdge(edge); });
+            connect((MyNewEdgeBuilderBase*)_newEdgeBuilder, &MyNewEdgeBuilderBase::askForEdgeUniqueName, this, [this] (MyNetworkElementStyleBase* edgeStyle) { return getElementUniqueName(this->edges(), edgeStyle->category()); });
+        }
+        ((MyNewEdgeBuilderBase*)_newEdgeBuilder)->build(element);
+        emit askForSetToolTip(((MyNewEdgeBuilderBase*)_newEdgeBuilder)->toolTipText());
+        if (((MyNewEdgeBuilderBase*)_newEdgeBuilder)->isNewEdgeBuilt()) {
+            deleteNewEdgeBuilder();
+            askForCreateChangeStageCommand();
+        }
+    }
+}
+
+void MyNetworkManager::removeEdge(MyNetworkElementBase* e) {
+    if (e && e->isActive()) {
+        _edges.removeOne(e);
+        e->setActive(false);
+        e->setSelected(false);
+        emit askForRemoveGraphicsItem(e->graphicsItem());
+        if (((MyEdgeBase*)e)->isSetArrowHead())
+            emit askForRemoveGraphicsItem(((MyEdgeBase*)e)->arrowHead()->graphicsItem());
+    }
+}
+
+void MyNetworkManager::deleteEdge(MyNetworkElementBase* edge) {
+    removeEdge(edge);
+    askForCreateChangeStageCommand();
+}
+
+void MyNetworkManager::moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance) {
+    MyNetworkElementMoverBase* nodeMover = new MyNodeMover(getSelectedNodes(), movedNode);
+    nodeMover->move(movedDistance.x(), movedDistance.y());
+    nodeMover->deleteLater();
+}
+
+void MyNetworkManager::deleteSelectedNetworkElements() {
+    for (MyNetworkElementBase* selectedNode : getSelectedNodes()) {
+        for (MyNetworkElementBase *edge : qAsConst(((MyNodeBase*)selectedNode)->edges())) {
+            ((MyNodeBase*)selectedNode)->removeEdge(edge);
+            removeEdge(edge);
+        }
+        removeNode(selectedNode);
+    }
+    for (MyNetworkElementBase* selectedEdge : getSelectedEdges()) {
+        if (selectedEdge) {
+            removeEdge(selectedEdge);
+        }
+    }
+    askForCreateChangeStageCommand();
+}
+
+void MyNetworkManager::alignSelectedNetworkElements(const QString& alignType) {
+    MyNetworkElementAlignerBase* networkElementAligner = createNetworkElementAligner(getSelectedNodes(), getSelectedEdges(), alignType);
+    if (networkElementAligner) {
+        networkElementAligner->align();
+        networkElementAligner->deleteLater();
+        askForCreateChangeStageCommand();
+    }
+}
+
+bool MyNetworkManager::isElementNameAlreadyUsed(const QString& elementName) {
+    for (MyNetworkElementBase* node : qAsConst(nodes())) {
+        if (node->name() == elementName)
+            return true;
+    }
+    for (MyNetworkElementBase* edge : qAsConst(edges())) {
+        if (edge->name() == elementName)
+            return true;
+    }
+
+    return false;
+}
+
+void MyNetworkManager::deleteNewEdgeBuilder() {
+    for (MyNetworkElementBase* selectedNode : getSelectedNodes())
+        selectedNode->setSelected(false);
+    if (_newEdgeBuilder)
+        _newEdgeBuilder->deleteLater();
+    _newEdgeBuilder = NULL;
+}
+
+bool MyNetworkManager::edgeExists(MyNetworkElementBase* n1, MyNetworkElementBase* n2) {
+    for (MyNetworkElementBase *edge : qAsConst(edges())) {
+        if ((((MyEdgeBase*)edge)->sourceNode() == n1 && ((MyEdgeBase*)edge)->targetNode() == n2) || (((MyEdgeBase*)edge)->sourceNode() == n2 && ((MyEdgeBase*)edge)->targetNode() == n1)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+QJsonObject MyNetworkManager::getNetworkElementsAndColorInfo() {
+    QJsonObject json;
+
+    // background color
+    json["background-color"] = askForNetworkBackgroundColor();
+
+    // nodes
+    QJsonArray nodesArray;
+    for (MyNetworkElementBase *node : qAsConst(nodes())) {
+        QJsonObject nodeObject;
+        node->write(nodeObject);
+        nodesArray.append(nodeObject);
+    }
+    json["nodes"] = nodesArray;
+
+    // edges
+    QJsonArray edgesArray;
+    for (MyNetworkElementBase *edge : qAsConst(edges())) {
+        QJsonObject edgeObject;
+        edge->write(edgeObject);
+        edgesArray.append(edgeObject);
+    }
+    json["edges"] = edgesArray;
+
+    return json;
+}
+
+QJsonObject MyNetworkManager::exportNetworkInfo() {
+    QJsonObject json = getNetworkElementsAndColorInfo();
+
+    QRectF networkExtents = askForItemsBoundingRect();
+    // position
+    QJsonObject positionObject;
+    positionObject["x"] = networkExtents.x() + 0.5 * networkExtents.width();
+    positionObject["y"] = networkExtents.y() + 0.5 * networkExtents.height();
+    json["position"] = positionObject;
+
+    // dimensions
+    QJsonObject dimensionsObject;
+    dimensionsObject["width"] = networkExtents.width();
+    dimensionsObject["height"] = networkExtents.height();
+    json["dimensions"] = dimensionsObject;
+
+    return json;
+}
+
+void MyNetworkManager::selectElements(const bool& selected) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectElements(selected);
+}
+
+void MyNetworkManager::selectElementsOfCategory(const bool& selected, const QString& category) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectElementsOfCategory(category, selected);
+}
+
+void MyNetworkManager::selectNodes(const bool& selected) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectNodes(selected);
+}
+
+void MyNetworkManager::selectNodesOfCategory(const bool& selected, const QString& category) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectNodesOfCategory(category, selected);
+}
+
+void MyNetworkManager::selectEdges(const bool& selected) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectEdges(selected);
+}
+
+void MyNetworkManager::selectEdgesOfCategory(const bool& selected, const QString& category) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectEdgesOfCategory(category, selected);
+}
+
+void MyNetworkManager::setElementSelected(const QString& elementName) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->setElementSelected(elementName);
+}
+
+MyNetworkElementBase* MyNetworkManager::getOneSingleSelectedElement() {
+    return ((MyNetworkElementSelector*)_networkElementSelector)->getOneSingleSelectedElement();
+}
+
+MyNetworkElementBase* MyNetworkManager::getOneSingleSelectedNode() {
+    return ((MyNetworkElementSelector*)_networkElementSelector)->getOneSingleSelectedElement();
+}
+
+MyNetworkElementBase* MyNetworkManager::getOneSingleSelectedEdge() {
+    return ((MyNetworkElementSelector*)_networkElementSelector)->getOneSingleSelectedElement();
+}
+
+const bool MyNetworkManager::canDisplaySingleElementFeatureMenu() {
+    return ((MyNetworkElementSelector*)_networkElementSelector)->canDisplaySingleElementFeatureMenu();
+}
+
+void MyNetworkManager::displaySelectionArea(const QPointF& position) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->displaySelectionArea(position);
+}
+
+void MyNetworkManager::createSelectionAreaGraphicsItem(const QPointF& position) {
+    ((MyNetworkElementSelector*)_networkElementSelector)->createSelectionAreaGraphicsItem(position);
+}
+
+void MyNetworkManager::selectSelectionAreaCoveredNodes() {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectSelectionAreaCoveredNodes();
+}
+
+void MyNetworkManager::selectSelectionAreaCoveredEdges() {
+    ((MyNetworkElementSelector*)_networkElementSelector)->selectSelectionAreaCoveredEdges();
+}
+
+void MyNetworkManager::clearSelectionArea() {
+    ((MyNetworkElementSelector*)_networkElementSelector)->clearSelectionArea();
+}

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -9,6 +9,7 @@
 #include "negui_edge_builder.h"
 #include "negui_network_element_aligner.h"
 #include "negui_network_element_aligner_builder.h"
+#include "negui_multi_network_element_feature_menu.h"
 
 #include <QJsonArray>
 
@@ -683,4 +684,34 @@ void MyNetworkManager::selectSelectionAreaCoveredEdges() {
 
 void MyNetworkManager::clearSelectionArea() {
     ((MyNetworkElementSelector*)_networkElementSelector)->clearSelectionArea();
+    displayFeatureMenu();
+}
+
+void MyNetworkManager::displayFeatureMenu() {
+    if (getOneSingleSelectedNode())
+        getOneSingleSelectedNode()->createFeatureMenu();
+    else if (getOneSingleSelectedEdge())
+        getOneSingleSelectedEdge()->createFeatureMenu();
+    else if (getSelectedElements().size()) {
+        QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), askForIconsDirectoryPath());
+        connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
+        askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
+    }
+    else
+        askForDisplayFeatureMenu();
+}
+
+void MyNetworkManager::displayFeatureMenu(QWidget* featureMenu) {
+    QString elementName = featureMenu->objectName();
+    if (canDisplaySingleElementFeatureMenu()) {
+        emit askForDisplayFeatureMenu(featureMenu);
+        emit singleNetworkElementFeatureMenuIsDisplayed(elementName);
+    }
+    else {
+        featureMenu->deleteLater();
+        QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), askForIconsDirectoryPath());
+        connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
+        emit askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
+        emit multiNetworkElementFeatureMenuIsDisplayed(elementName);
+    }
 }

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -684,10 +684,10 @@ void MyNetworkManager::selectSelectionAreaCoveredEdges() {
 
 void MyNetworkManager::clearSelectionArea() {
     ((MyNetworkElementSelector*)_networkElementSelector)->clearSelectionArea();
-    displayFeatureMenu();
+    updateFeatureMenu();
 }
 
-void MyNetworkManager::displayFeatureMenu() {
+void MyNetworkManager::updateFeatureMenu() {
     if (askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()) {
         if (getOneSingleSelectedNode())
             getOneSingleSelectedNode()->createFeatureMenu();
@@ -699,7 +699,7 @@ void MyNetworkManager::displayFeatureMenu() {
             askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
         }
         else
-            askForDisplayFeatureMenu();
+            askForDisplayNullFeatureMenu();
     }
 }
 

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -396,7 +396,7 @@ void MyNetworkManager::addNode(MyNetworkElementBase* n) {
         connect(n, &MyNetworkElementBase::askForPasteNetworkElementStyle, this, [this] (MyNetworkElementBase* networkElement) { pasteCopiedNodeStyle(networkElement); });
         connect(n, &MyNetworkElementBase::askForWhetherElementStyleIsCopied, this, [this] () { return isSetCopiedNodeStyle(); } );
         connect(n, &MyNetworkElementBase::askForWhetherAnyOtherElementsAreSelected, this, [this] (QList<MyNetworkElementBase*> networkElements) {
-            ((MyNetworkElementSelector*)_networkElementSelector)->areAnyOtherElementsSelected(networkElements); });
+            return ((MyNetworkElementSelector*)_networkElementSelector)->areAnyOtherElementsSelected(networkElements); });
         connect(n, SIGNAL(askForIconsDirectoryPath()), this, SIGNAL(askForIconsDirectoryPath()));
         connect(n, SIGNAL(positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&)), this, SLOT(moveSelectedNetworkElements(MyNetworkElementBase*, const QPointF&)));
         connect(n, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
@@ -465,7 +465,7 @@ void MyNetworkManager::addEdge(MyNetworkElementBase* e) {
         connect(e, &MyNetworkElementBase::askForCopyNetworkElementStyle, this, [this] (MyNetworkElementStyleBase* style) { setCopiedEdgeStyle(style); });
         connect(e, &MyNetworkElementBase::askForPasteNetworkElementStyle, this, [this] (MyNetworkElementBase* networkElement) { pasteCopiedEdgeStyle(networkElement); });
         connect(e, &MyNetworkElementBase::askForWhetherAnyOtherElementsAreSelected, this, [this] (QList<MyNetworkElementBase*> networkElements) {
-            ((MyNetworkElementSelector*)_networkElementSelector)->areAnyOtherElementsSelected(networkElements); });
+            return ((MyNetworkElementSelector*)_networkElementSelector)->areAnyOtherElementsSelected(networkElements); });
         connect(e, &MyNetworkElementBase::askForWhetherElementStyleIsCopied, this, [this] () { return isSetCopiedEdgeStyle(); } );
         connect(e, SIGNAL(askForIconsDirectoryPath()), this, SIGNAL(askForIconsDirectoryPath()));
         connect(e->graphicsItem(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -3,12 +3,12 @@
 #include "negui_copied_network_elements_paster.h"
 #include "negui_network_element_selector.h"
 #include "negui_network_element_mover.h"
+#include "negui_network_element_aligner.h"
+#include "negui_network_element_aligner_builder.h"
 #include "negui_node.h"
 #include "negui_node_builder.h"
 #include "negui_edge.h"
 #include "negui_edge_builder.h"
-#include "negui_network_element_aligner.h"
-#include "negui_network_element_aligner_builder.h"
 #include "negui_multi_network_element_feature_menu.h"
 
 #include <QJsonArray>
@@ -688,17 +688,19 @@ void MyNetworkManager::clearSelectionArea() {
 }
 
 void MyNetworkManager::displayFeatureMenu() {
-    if (getOneSingleSelectedNode())
-        getOneSingleSelectedNode()->createFeatureMenu();
-    else if (getOneSingleSelectedEdge())
-        getOneSingleSelectedEdge()->createFeatureMenu();
-    else if (getSelectedElements().size()) {
-        QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), askForIconsDirectoryPath());
-        connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
-        askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
+    if (askForCurrentlyBeingDisplayedNetworkElementFeatureMenu()) {
+        if (getOneSingleSelectedNode())
+            getOneSingleSelectedNode()->createFeatureMenu();
+        else if (getOneSingleSelectedEdge())
+            getOneSingleSelectedEdge()->createFeatureMenu();
+        else if (getSelectedElements().size()) {
+            QWidget* multiNetworkElementFeatureMenu = new MyMultiNetworkElementFeatureMenu(getSelectedElements(), askForIconsDirectoryPath());
+            connect(multiNetworkElementFeatureMenu, SIGNAL(askForCreateChangeStageCommand()), this, SIGNAL(askForCreateChangeStageCommand()));
+            askForDisplayFeatureMenu(multiNetworkElementFeatureMenu);
+        }
+        else
+            askForDisplayFeatureMenu();
     }
-    else
-        askForDisplayFeatureMenu();
 }
 
 void MyNetworkManager::displayFeatureMenu(QWidget* featureMenu) {

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -15,6 +15,7 @@
 MyNetworkManager::MyNetworkManager() {
     _newEdgeBuilder = NULL;
     setNetworkElementSelector();
+    resetNetwork();
 }
 
 void MyNetworkManager::enableNormalMode() {
@@ -33,9 +34,9 @@ void MyNetworkManager::enableNormalMode() {
         edge->enableNormalMode();
 }
 
-void MyNetworkManager::enableAddNodeMode(MyNetworkElementStyleBase* style) {
+void MyNetworkManager::enableAddNodeMode(MyPluginItemBase* style) {
     MySceneModeElementBase::enableAddNodeMode();
-    setNodeStyle(style);
+    setNodeStyle(dynamic_cast<MyNetworkElementStyleBase*>(style));
     ((MyNetworkElementSelector*)_networkElementSelector)->enableAddNodeMode();
     for (MyNetworkElementBase *node : qAsConst(nodes()))
         node->enableAddNodeMode();
@@ -43,9 +44,9 @@ void MyNetworkManager::enableAddNodeMode(MyNetworkElementStyleBase* style) {
         edge->enableAddNodeMode();
 }
 
-void MyNetworkManager::enableAddEdgeMode(MyNetworkElementStyleBase* style) {
+void MyNetworkManager::enableAddEdgeMode(MyPluginItemBase* style) {
     MySceneModeElementBase::enableAddEdgeMode();
-    setEdgeStyle(style);
+    setEdgeStyle(dynamic_cast<MyNetworkElementStyleBase*>(style));
     ((MyNetworkElementSelector*)_networkElementSelector)->enableAddEdgeMode();
     for (MyNetworkElementBase *node : qAsConst(nodes()))
         node->enableAddEdgeMode();

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -173,7 +173,7 @@ public:
 
     void clearSelectionArea();
 
-    void displayFeatureMenu();
+    void updateFeatureMenu();
 
     void displayFeatureMenu(QWidget* featureMenu);
 
@@ -213,7 +213,7 @@ signals:
 
     QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
 
-    void askForDisplayFeatureMenu();
+    void askForDisplayNullFeatureMenu();
 
     void askForDisplayFeatureMenu(QWidget*);
 

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -173,6 +173,10 @@ public:
 
     void clearSelectionArea();
 
+    void displayFeatureMenu();
+
+    void displayFeatureMenu(QWidget* featureMenu);
+
 signals:
 
     void askForClearScene();
@@ -208,6 +212,8 @@ signals:
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
 
     QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
+
+    void askForDisplayFeatureMenu();
 
     void askForDisplayFeatureMenu(QWidget*);
 

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -13,9 +13,9 @@ public:
 
     void enableNormalMode() override;
 
-    void enableAddNodeMode(MyNetworkElementStyleBase* style);
+    void enableAddNodeMode(MyPluginItemBase* style);
 
-    void enableAddEdgeMode(MyNetworkElementStyleBase* style);
+    void enableAddEdgeMode(MyPluginItemBase* style);
 
     void enableSelectMode() override;
 

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -1,0 +1,246 @@
+#ifndef __NEGUI_NETWORK_MANAGER_H
+#define __NEGUI_NETWORK_MANAGER_H
+
+#include "negui_network_element_base.h"
+#include "negui_network_element_style_base.h"
+
+class MyNetworkManager : public QObject, public MySceneModeElementBase {
+    Q_OBJECT
+
+public:
+
+    MyNetworkManager();
+
+    void enableNormalMode() override;
+
+    void enableAddNodeMode(MyNetworkElementStyleBase* style);
+
+    void enableAddEdgeMode(MyNetworkElementStyleBase* style);
+
+    void enableSelectMode() override;
+
+    void enableSelectNodeMode() override;
+
+    void enableSelectEdgeMode() override;
+
+    QList<MyNetworkElementBase*>& nodes();
+
+    QList<MyNetworkElementBase*>& edges();
+
+    void clearNodesInfo();
+
+    void clearEdgesInfo();
+
+    MyNetworkElementStyleBase* nodeStyle();
+
+    void setNodeStyle(MyNetworkElementStyleBase* style);
+
+    MyNetworkElementStyleBase* copiedNodeStyle();
+
+    void setCopiedNodeStyle(MyNetworkElementStyleBase* style);
+
+    bool isSetCopiedNodeStyle();
+
+    void pasteCopiedNodeStyle(MyNetworkElementBase* element);
+
+    MyNetworkElementStyleBase* edgeStyle();
+
+    void setEdgeStyle(MyNetworkElementStyleBase* style);
+
+    MyNetworkElementStyleBase* copiedEdgeStyle();
+
+    void setCopiedEdgeStyle(MyNetworkElementStyleBase* style);
+
+    const bool isSetCopiedEdgeStyle();
+
+    void pasteCopiedEdgeStyle(MyNetworkElementBase* element);
+
+    void setNetworkElementSelector();
+
+    void createNetwork(const QJsonObject& json);
+
+    void resetNetworkCanvas();
+
+    void resetNetwork();
+
+    void resetCanvas();
+
+    void setBackground(const QJsonObject &json);
+
+    void addNodes(const QJsonObject &json);
+
+    void addNode(const QJsonObject &json);
+
+    void addNewNode(const QPointF& position);
+
+    void addNode(MyNetworkElementBase* n);
+
+    void deleteNode(MyNetworkElementBase* node);
+
+    void removeNode(MyNetworkElementBase* n);
+
+    void updateNodeParents();
+
+    void addEdges(const QJsonObject &json);
+
+    void addEdge(const QJsonObject &json);
+
+    void addEdge(MyNetworkElementBase* e);
+
+    void addNewEdge(MyNetworkElementBase* element);
+
+    void removeEdge(MyNetworkElementBase* e);
+
+    void deleteEdge(MyNetworkElementBase* edge);
+
+    void changeElementSelectionsStatus(MyNetworkElementBase* element);
+
+    const bool areSelectedElementsCopyable();
+
+    const bool areSelectedElementsCuttable();
+
+    const bool areSelectedElementsAlignable();
+
+    const bool areAnyElementsCopied();
+
+    const bool areAnyElementsSelected();
+
+    void copySelectedNetworkElements();
+
+    void cutSelectedNetworkElements();
+
+    void pasteCopiedNetworkElements();
+
+    void pasteCopiedNetworkElements(const QPointF& position);
+
+    const QList<MyNetworkElementBase*> getSelectedElements();
+
+    const QList<MyNetworkElementBase*> getSelectedNodes();
+
+    const QList<MyNetworkElementBase*> getSelectedEdges();
+
+    void setCutNode(MyNetworkElementBase* node);
+
+    void setCopiedNode(MyNetworkElementBase* node);
+
+    QList<MyNetworkElementBase*> copiedNetworkElements();
+
+    void resetCopiedNetworkElements();
+
+    bool isElementNameAlreadyUsed(const QString& elementName);
+
+    void deleteNewEdgeBuilder();
+
+    bool edgeExists(MyNetworkElementBase* n1, MyNetworkElementBase* n2);
+
+    QJsonObject getNetworkElementsAndColorInfo();
+
+    QJsonObject exportNetworkInfo();
+
+    void deleteSelectedNetworkElements();
+
+    void alignSelectedNetworkElements(const QString& alignType);
+
+    void selectElements(const bool& selected);
+
+    void selectElementsOfCategory(const bool& selected, const QString& category);
+
+    void selectNodes(const bool& selected);
+
+    void selectNodesOfCategory(const bool& selected, const QString& category);
+
+    void selectEdges(const bool& selected);
+
+    void selectEdgesOfCategory(const bool& selected, const QString& category);
+
+    void setElementSelected(const QString& elementName);
+
+    MyNetworkElementBase* getOneSingleSelectedElement();
+
+    MyNetworkElementBase* getOneSingleSelectedNode();
+
+    MyNetworkElementBase* getOneSingleSelectedEdge();
+
+    const bool canDisplaySingleElementFeatureMenu();
+
+    void displaySelectionArea(const QPointF& position);
+
+    void createSelectionAreaGraphicsItem(const QPointF& position);
+
+    void selectSelectionAreaCoveredNodes();
+
+    void selectSelectionAreaCoveredEdges();
+
+    void clearSelectionArea();
+
+signals:
+
+    void askForClearScene();
+
+    void askForCreateChangeStageCommand();
+
+    void askForAddGraphicsItem(QGraphicsItem*);
+
+    void askForRemoveGraphicsItem(QGraphicsItem*);
+
+    void singleNetworkElementFeatureMenuIsDisplayed(const QString&);
+
+    void multiNetworkElementFeatureMenuIsDisplayed(const QString&);
+
+    void elementsCuttableStatusChanged(const bool&);
+
+    void elementsCopyableStatusChanged(const bool&);
+
+    const bool askForWhetherShiftModifierIsPressed();
+
+    const bool askForWhetherControlModifierIsPressed();
+
+    void askForAdjustExtentsOfNodes();
+
+    void askForAdjustConnectedEdgesOfNodes();
+
+    void askForDisplaySceneContextMenu(const QPointF&);
+
+    const QString askForIconsDirectoryPath();
+
+    void pasteElementsStatusChanged(const bool&);
+
+    QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
+
+    QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
+
+    void askForDisplayFeatureMenu(QWidget*);
+
+    void askForSetToolTip(const QString&);
+
+    void askForSetNetworkBackgroundColor(const QString&);
+
+    const QString askForNetworkBackgroundColor();
+
+    QRectF askForItemsBoundingRect();
+
+    void askForResetScale();
+
+    void askForEnableNormalMode();
+
+    void askForClearUndoStack();
+
+public slots:
+
+    void moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance);
+
+protected:
+
+    QList<MyNetworkElementBase*> _nodes;
+    QList<MyNetworkElementBase*> _edges;
+    MyNetworkElementStyleBase* _nodeStyle;
+    MyNetworkElementStyleBase* _copiedNodeStyle;
+    MyNetworkElementStyleBase* _edgeStyle;
+    MyNetworkElementStyleBase* _copiedEdgeStyle;
+    QList<MyNetworkElementBase*> _copiedNetworkElements;
+
+    QObject* _newEdgeBuilder;
+    QObject* _networkElementSelector;
+};
+
+#endif

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -183,6 +183,8 @@ signals:
 
     void askForRemoveGraphicsItem(QGraphicsItem*);
 
+    void networkElementsSelectedStatusIsChanged();
+
     void elementsCuttableStatusChanged(const bool&);
 
     void elementsCopyableStatusChanged(const bool&);
@@ -204,6 +206,8 @@ signals:
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
 
     void askForEnableFeatureMenuDisplay();
+
+    QWidget* askForCurrentlyBeingDisplayedFeatureMenu();
 
     bool askForWhetherFeatureMenuCanBeDisplayed();
 

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -161,8 +161,6 @@ public:
 
     MyNetworkElementBase* getOneSingleSelectedEdge();
 
-    const bool canDisplaySingleElementFeatureMenu();
-
     void displaySelectionArea(const QPointF& position);
 
     void createSelectionAreaGraphicsItem(const QPointF& position);
@@ -175,8 +173,6 @@ public:
 
     void updateFeatureMenu();
 
-    void displayFeatureMenu(QWidget* featureMenu);
-
 signals:
 
     void askForClearScene();
@@ -186,10 +182,6 @@ signals:
     void askForAddGraphicsItem(QGraphicsItem*);
 
     void askForRemoveGraphicsItem(QGraphicsItem*);
-
-    void singleNetworkElementFeatureMenuIsDisplayed(const QString&);
-
-    void multiNetworkElementFeatureMenuIsDisplayed(const QString&);
 
     void elementsCuttableStatusChanged(const bool&);
 
@@ -211,7 +203,9 @@ signals:
 
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
 
-    QWidget* askForCurrentlyBeingDisplayedNetworkElementFeatureMenu();
+    void askForEnableFeatureMenuDisplay();
+
+    bool askForWhetherFeatureMenuCanBeDisplayed();
 
     void askForDisplayNullFeatureMenu();
 

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -205,7 +205,7 @@ signals:
 
     void askForDisplaySceneContextMenu(const QPointF&);
 
-    const QString askForIconsDirectoryPath();
+    QString askForIconsDirectoryPath();
 
     void pasteElementsStatusChanged(const bool&);
 

--- a/src/negui_plugin_manager.cpp
+++ b/src/negui_plugin_manager.cpp
@@ -174,7 +174,7 @@ void MyPluginManager::addPluginItem(MyPluginItemBase* pluginItem) {
     _pluginItems.push_back(pluginItem);
 }
 
-const QStringList MyPluginManager::listOfPluginItemNames(const QString type) {
+QStringList MyPluginManager::listOfPluginItemNames(const QString type) {
     QStringList pluginItemNames;
     QList<MyPluginItemBase*> pluginsOfType = getPluginsOfType(pluginItems(), type);
     for (MyPluginItemBase* pluginOfType: pluginsOfType)
@@ -183,7 +183,7 @@ const QStringList MyPluginManager::listOfPluginItemNames(const QString type) {
     return pluginItemNames;
 }
 
-const QStringList MyPluginManager::listOfPluginItemCategories(const QString type) {
+QStringList MyPluginManager::listOfPluginItemCategories(const QString type) {
     QStringList pluginItemCategories;
     QList<MyPluginItemBase*> pluginsOfType = getPluginsOfType(pluginItems(), type);
     for (MyPluginItemBase* pluginOfType: pluginsOfType)

--- a/src/negui_plugin_manager.h
+++ b/src/negui_plugin_manager.h
@@ -46,9 +46,9 @@ public:
 
     QList<MyPluginItemBase*>& pluginItems();
 
-    const QStringList listOfPluginItemNames(const QString type);
+    QStringList listOfPluginItemNames(const QString type);
 
-    const QStringList listOfPluginItemCategories(const QString type);
+    QStringList listOfPluginItemCategories(const QString type);
 
     void addPluginItem(MyPluginItemBase* pluginItem);
 
@@ -76,7 +76,7 @@ signals:
 
     QString askForCurrentBaseFileName();
 
-    const QJsonObject askForNetworkInfo();
+    QJsonObject askForNetworkInfo();
 
     void networkInfoIsReadFromFile(const QJsonObject&, MyPluginItemBase*, const QString&);
 

--- a/src/negui_plugin_manager.h
+++ b/src/negui_plugin_manager.h
@@ -70,7 +70,7 @@ public:
 
 signals:
 
-    const QString askForApplicationDirectoryPath();
+    QString askForApplicationDirectoryPath();
 
     QString askForWorkingDirectoryPath();
 


### PR DESCRIPTION
- network manager class is created and extracted from interactor

- menu button manger is extracted from interactor

- the contents of display feature menu are moved to network manager

- enter key pressed event is no longer used and deprecated

- selection area now select/unselect menu once it is cleared
    
- once the graphics item is double-clicked a signal is passed from it indicating that the menu must be shown (no menu is created at this stage anymore)
    
- once network elements selection status is changed, it is checked that whether the feature menu needs to be updated or not

- - currently being displayed menu is passed to the network element base to expand the last used geometric shape style in the new menu
