### PR TITLE
The probelm with the position to which the copied network elements are pasted is fixed

### DIFF
--- a/src/negui_call_api_function.cpp
+++ b/src/negui_call_api_function.cpp
@@ -51,10 +51,6 @@ const QJsonValue callAPIFunction(QObject* mainWidget, const QString& functionNam
             ((MyMainWidget*)mainWidget)->copySelectedNetworkElements();
         else if (functionName == "pasteCopiedNetworkElements")
             ((MyMainWidget*)mainWidget)->pasteCopiedNetworkElements();
-        else if (functionName == "pasteCopiedNetworkElements") {
-            if (inputArray.size() == 2 && inputArray[0].isDouble() && inputArray[1].isDouble())
-                ((MyMainWidget*)mainWidget)->pasteCopiedNetworkElements(inputArray[0].toDouble(), inputArray[1].toDouble());
-        }
         else if (functionName == "resetCopiedNetworkElements")
             ((MyMainWidget*)mainWidget)->resetCopiedNetworkElements();
         else if (functionName == "areSelectedElementsCopyable")

--- a/src/negui_graphics_scene.cpp
+++ b/src/negui_graphics_scene.cpp
@@ -67,6 +67,10 @@ QList<QGraphicsItem *> MyGraphicsScene::itemsAtPosition(const QPointF& position)
     return QGraphicsScene::items(position);
 }
 
+const QPointF MyGraphicsScene::cursorPosition() {
+    return _cursorPosition;
+}
+
 const bool MyGraphicsScene::isShiftModifierPressed() {
     return _isShiftModifierPressed;
 }
@@ -85,7 +89,7 @@ QMenu* MyGraphicsScene::createContextMenu() {
 void MyGraphicsScene::connectContextMenu(QMenu* contextMenu) {
     connect(contextMenu, SIGNAL(askForCopySelectedNetworkElements()), this, SIGNAL(askForCopySelectedNetworkElements()));
     connect(contextMenu, SIGNAL(askForCutSelectedNetworkElements()), this, SIGNAL(askForCutSelectedNetworkElements()));
-    connect((MyGraphicsSceneContextMenu*)contextMenu, &MyGraphicsSceneContextMenu::askForPasteCopiedNetworkElements, this, [this] () { emit askForPasteCopiedNetworkElements(_cursorPosition); });
+    connect((MyGraphicsSceneContextMenu*)contextMenu, &MyGraphicsSceneContextMenu::askForPasteCopiedNetworkElements, this, [this] () { emit askForPasteCopiedNetworkElements(); });
     connect(contextMenu, SIGNAL(askForDeleteSelectedNetworkElements()), this, SIGNAL(askForDeleteSelectedNetworkElements()));
     connect(contextMenu, SIGNAL(askForAlignSelectedNetworkElements(const QString&)), this, SIGNAL(askForAlignSelectedNetworkElements(const QString&)));
     connect(contextMenu, SIGNAL(askForWhetherSelectedElementsAreCopyable()), this, SIGNAL(askForWhetherSelectedElementsAreCopyable()));
@@ -172,7 +176,7 @@ void MyGraphicsScene::keyPressEvent(QKeyEvent *event) {
             else if (event->modifiers() == Qt::ControlModifier && event->key() == Qt::Key_X)
                 emit askForCutSelectedNetworkElements();
             else if (event->modifiers() == Qt::ControlModifier && event->key() == Qt::Key_V)
-                emit askForPasteCopiedNetworkElements(_cursorPosition);
+                emit askForPasteCopiedNetworkElements();
             else if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace)
                 emit askForDeleteSelectedNetworkElements();
             else if (event->modifiers() == Qt::ControlModifier)

--- a/src/negui_graphics_scene.h
+++ b/src/negui_graphics_scene.h
@@ -11,7 +11,7 @@
 
 class MyGraphicsScene :public QGraphicsScene, public MySceneModeElementBase {
     Q_OBJECT
-    
+
 public:
     
     MyGraphicsScene(QWidget* parent = nullptr);
@@ -39,7 +39,7 @@ signals:
     bool askForWhetherAnyElementsAreSelected();
     void askForCopySelectedNetworkElements();
     void askForCutSelectedNetworkElements();
-    void askForPasteCopiedNetworkElements(const QPointF&);
+    void askForPasteCopiedNetworkElements();
     void askForDeleteSelectedNetworkElements();
     void askForAlignSelectedNetworkElements(const QString&);
 
@@ -53,13 +53,14 @@ public slots:
     void setBackgroundColor(const QString& backgroundColor);
     void clearScene();
     QList<QGraphicsItem *> itemsAtPosition(const QPointF& position);
+    const QPointF cursorPosition();
     const bool isShiftModifierPressed();
     const bool isControlModifierPressed();
     void displayContextMenu(const qreal& x, const qreal& y);
     const bool whetherMouseReleaseEventIsAccepted();
     
 protected:
-    
+
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -261,11 +261,7 @@ void MyInteractor::cutSelectedNetworkElements() {
 }
 
 void MyInteractor::pasteCopiedNetworkElements() {
-    ((MyNetworkManager*)_networkManager)->pasteCopiedNetworkElements();
-}
-
-void MyInteractor::pasteCopiedNetworkElements(const qreal& x, const qreal& y) {
-    ((MyNetworkManager*)_networkManager)->pasteCopiedNetworkElements(QPointF(x, y));
+    ((MyNetworkManager*)_networkManager)->pasteCopiedNetworkElements(askForCursorPosition());
 }
 
 void MyInteractor::resetCopiedNetworkElements() {

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -51,6 +51,7 @@ signals:
     void askForDisplayFeatureMenu(QWidget*);
     QWidget* askForCurrentlyBeingDisplayedFeatureMenu();
     QList<QGraphicsItem *> askForItemsAtPosition(const QPointF& position);
+    const QPointF askForCursorPosition();
     void modeIsSet(const QString&);
     void currentFileNameIsUpdated(const QString&);
     void elementsCuttableStatusChanged(const bool&);
@@ -86,7 +87,6 @@ public slots:
     void cutSelectedNetworkElements();
     void copySelectedNetworkElements();
     void pasteCopiedNetworkElements();
-    void pasteCopiedNetworkElements(const qreal& x, const qreal& y);
     void resetCopiedNetworkElements();
     const bool areSelectedElementsCopyable();
     const bool areSelectedElementsCuttable();

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -114,6 +114,9 @@ void MyMainWidget::setInteractions() {
     // items at position
     connect((MyInteractor*)interactor(), SIGNAL(askForItemsAtPosition(const QPointF&)), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(itemsAtPosition(const QPointF&)));
 
+    // cursor position
+    connect((MyInteractor*)interactor(), SIGNAL(askForCursorPosition()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(cursorPosition()));
+
     // activated shift modifier
     connect((MyInteractor*)interactor(), SIGNAL(askForWhetherShiftModifierIsPressed()), ((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), SLOT(isShiftModifierPressed()));
 
@@ -146,7 +149,7 @@ void MyMainWidget::setInteractions() {
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForWhetherAnyElementsAreAlignable, this, [this] () { return ((MyInteractor*)interactor())->areSelectedElementsAlignable(); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForCopySelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->copySelectedNetworkElements(); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForCutSelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->cutSelectedNetworkElements(); });
-    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForPasteCopiedNetworkElements, this, [this] (const QPointF & position) { ((MyInteractor*)interactor())->pasteCopiedNetworkElements(); });
+    connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForPasteCopiedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->pasteCopiedNetworkElements(); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForDeleteSelectedNetworkElements, this, [this] () { ((MyInteractor*)interactor())->deleteSelectedNetworkElements(); });
     connect(((MyGraphicsScene*)((MyGraphicsView*)view())->scene()), &MyGraphicsScene::askForAlignSelectedNetworkElements, this, [this] (const QString& type)  { ((MyInteractor*)interactor())->alignSelectedNetworkElements(type); });
     connect((MyInteractor*)interactor(), SIGNAL(askForDisplaySceneContextMenu(const qreal&, const qreal&)), ((MyGraphicsView*)view())->scene(), SLOT(displayContextMenu(const qreal&, const qreal&)));
@@ -362,10 +365,6 @@ void MyMainWidget::copySelectedNetworkElements() {
 
 void MyMainWidget::pasteCopiedNetworkElements() {
     ((MyInteractor*)interactor())->pasteCopiedNetworkElements();
-}
-
-void MyMainWidget::pasteCopiedNetworkElements(const qreal& x, const qreal& y) {
-    ((MyInteractor*)interactor())->pasteCopiedNetworkElements(x, y);
 }
 
 void MyMainWidget::resetCopiedNetworkElements() {

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -63,7 +63,6 @@ public slots:
     void cutSelectedNetworkElements();
     void copySelectedNetworkElements();
     void pasteCopiedNetworkElements();
-    void pasteCopiedNetworkElements(const qreal& x, const qreal& y);
     void resetCopiedNetworkElements();
     const bool areSelectedElementsCopyable();
     const bool areSelectedElementsCuttable();

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -248,10 +248,6 @@ void MyNetworkManager::cutSelectedNetworkElements() {
     }
 }
 
-void MyNetworkManager::pasteCopiedNetworkElements() {
-    pasteCopiedNetworkElements(askForItemsBoundingRect().center());
-}
-
 void MyNetworkManager::pasteCopiedNetworkElements(const QPointF& position) {
     MyCopiedNetworkElementsPaster* copiedNetworkElementsPaster = new MyCopiedNetworkElementsPaster(copiedNetworkElements(), position);
     connect(copiedNetworkElementsPaster, &MyCopiedNetworkElementsPaster::askForAddNode, this, [this] (MyNetworkElementBase* node) { this->addNode(node); });

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -123,8 +123,6 @@ public:
 
     void cutSelectedNetworkElements();
 
-    void pasteCopiedNetworkElements();
-
     void pasteCopiedNetworkElements(const QPointF& position);
 
     const QList<MyNetworkElementBase*> getSelectedElements();


### PR DESCRIPTION
-  paste copied network element api function no longer receives an input

- the interactor now asks for cursor position each time paste function is called

This PR fixes #131 and fixes #132 issues.