### PR TITLE
Update how nodes positions are stored, set, and updated

### DIFF
--- a/src/negui_1d_shape_graphics_item_base.cpp
+++ b/src/negui_1d_shape_graphics_item_base.cpp
@@ -10,8 +10,8 @@ const qreal My1DShapeGraphicsItemBase::getEndSlope() {
     return 0.0;
 }
 
-void My1DShapeGraphicsItemBase::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
-    
+void My1DShapeGraphicsItemBase::moveOriginalPosition(const qreal& dx, const qreal& dy) {
+
 }
 
 void My1DShapeGraphicsItemBase::updateExtents(const QRectF& extents) {

--- a/src/negui_1d_shape_graphics_item_base.cpp
+++ b/src/negui_1d_shape_graphics_item_base.cpp
@@ -10,6 +10,10 @@ const qreal My1DShapeGraphicsItemBase::getEndSlope() {
     return 0.0;
 }
 
+void My1DShapeGraphicsItemBase::updateOriginalPosition(const QPointF originalPosition) {
+
+}
+
 void My1DShapeGraphicsItemBase::moveOriginalPosition(const qreal& dx, const qreal& dy) {
 
 }

--- a/src/negui_1d_shape_graphics_item_base.h
+++ b/src/negui_1d_shape_graphics_item_base.h
@@ -11,6 +11,8 @@ public:
     virtual const qreal getEndSlope();
     
     virtual void setLine(const QLineF& line) = 0;
+
+    void updateOriginalPosition(const QPointF originalPosition) override;
     
     void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     

--- a/src/negui_1d_shape_graphics_item_base.h
+++ b/src/negui_1d_shape_graphics_item_base.h
@@ -12,7 +12,7 @@ public:
     
     virtual void setLine(const QLineF& line) = 0;
     
-    void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) override;
+    void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:
     virtual void updateExtents(const QRectF& extents) override;

--- a/src/negui_arrow_head.cpp
+++ b/src/negui_arrow_head.cpp
@@ -62,12 +62,12 @@ void MyArrowHeadBase::setSelectedWithColor(const bool& selected) {
         graphicsItem()->setSelectedWithFillColor(selected);
 }
 
-const bool MyArrowHeadBase::canBeMovedExternally() {
+const bool MyArrowHeadBase::canBeMoved() {
     return false;
 }
 
-void MyArrowHeadBase::moveExternally(const qreal& dx, const qreal& dy) {
-    if (canBeMovedExternally())
+void MyArrowHeadBase::move(const qreal& dx, const qreal& dy) {
+    if (canBeMoved())
         return;
 }
 

--- a/src/negui_arrow_head.h
+++ b/src/negui_arrow_head.h
@@ -32,9 +32,9 @@ public:
 
     void setSelectedWithColor(const bool& selected) override;
 
-    const bool canBeMovedExternally() override;
+    const bool canBeMoved() override;
 
-    void moveExternally(const qreal& dx, const qreal& dy) override;
+    void move(const qreal& dx, const qreal& dy) override;
 
     const QRectF getExtents() override;
 

--- a/src/negui_centroid_graphics_item.cpp
+++ b/src/negui_centroid_graphics_item.cpp
@@ -38,12 +38,13 @@ void MyCentroidGraphicsItem::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyCentroidGraphicsItem::getExtents() {
-    return QRectF(- ((MyCentroidStyleBase*)style())->radius() + _originalPosition.x(), - ((MyCentroidStyleBase*)style())->radius() + _originalPosition.y(), 2 * ((MyCentroidStyleBase*)style())->radius(), 2 * ((MyCentroidStyleBase*)style())->radius());
+    return QRectF(- ((MyCentroidStyleBase*)style())->radius() + _originalPosition.x() + _movedOriginalPosition.x(),
+                  - ((MyCentroidStyleBase*)style())->radius() + _originalPosition.y() + _movedOriginalPosition.y(),
+                  2 * ((MyCentroidStyleBase*)style())->radius(), 2 * ((MyCentroidStyleBase*)style())->radius());
 }
 
 void MyCentroidGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
-    _originalPosition += QPointF(dx, dy);
-    My2DShapeGraphicsItemBase::updateExtents();
+    _movedOriginalPosition += QPointF(dx, dy);
 }
 
 QGraphicsItem* MyCentroidGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_centroid_graphics_item.cpp
+++ b/src/negui_centroid_graphics_item.cpp
@@ -43,6 +43,10 @@ QRectF MyCentroidGraphicsItem::getExtents() {
                   2 * ((MyCentroidStyleBase*)style())->radius(), 2 * ((MyCentroidStyleBase*)style())->radius());
 }
 
+void MyCentroidGraphicsItem::updateOriginalPosition(const QPointF originalPosition) {
+    _originalPosition = originalPosition - _movedOriginalPosition;
+}
+
 void MyCentroidGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
     _movedOriginalPosition += QPointF(dx, dy);
 }

--- a/src/negui_centroid_graphics_item.cpp
+++ b/src/negui_centroid_graphics_item.cpp
@@ -38,11 +38,12 @@ void MyCentroidGraphicsItem::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyCentroidGraphicsItem::getExtents() {
-    return QRectF(- ((MyCentroidStyleBase*)style())->radius() + (movedDistance().x() + _originalPosition.x()), - ((MyCentroidStyleBase*)style())->radius() + (movedDistance().y() + _originalPosition.y()), 2 * ((MyCentroidStyleBase*)style())->radius(), 2 * ((MyCentroidStyleBase*)style())->radius());
+    return QRectF(- ((MyCentroidStyleBase*)style())->radius() + _originalPosition.x(), - ((MyCentroidStyleBase*)style())->radius() + _originalPosition.y(), 2 * ((MyCentroidStyleBase*)style())->radius(), 2 * ((MyCentroidStyleBase*)style())->radius());
 }
 
-void MyCentroidGraphicsItem::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
-
+void MyCentroidGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
+    _originalPosition += QPointF(dx, dy);
+    My2DShapeGraphicsItemBase::updateExtents();
 }
 
 QGraphicsItem* MyCentroidGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_centroid_graphics_item.h
+++ b/src/negui_centroid_graphics_item.h
@@ -24,6 +24,8 @@ public:
     
     void setZValue(qreal z) override;
 
+    void updateOriginalPosition(const QPointF originalPosition) override;
+
     void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
 
 signals:

--- a/src/negui_centroid_graphics_item.h
+++ b/src/negui_centroid_graphics_item.h
@@ -24,7 +24,7 @@ public:
     
     void setZValue(qreal z) override;
 
-    void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) override;
+    void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
 
 signals:
 

--- a/src/negui_copied_network_elements_paster.cpp
+++ b/src/negui_copied_network_elements_paster.cpp
@@ -35,7 +35,8 @@ void MyCopiedNetworkElementsPaster::pasteNodes() {
 
 MyNetworkElementBase* MyCopiedNetworkElementsPaster::createPastedNode(MyNetworkElementBase* node, const QPointF& movedCenter) {
     QString pastedNodeName = askForNodeUniqueName(node->style());
-    return createNode(pastedNodeName, getCopyNodeStyle(pastedNodeName, node->style()), ((MyNodeBase*)node)->position().x() + movedCenter.x(), ((MyNodeBase*)node)->position().y() + movedCenter.y());
+    QPointF pastedNodePosition = ((MyNodeBase*)node)->getPosition();
+    return createNode(pastedNodeName, getCopyNodeStyle(pastedNodeName, node->style()), pastedNodePosition.x() + movedCenter.x(), pastedNodePosition.y() + movedCenter.y());
 }
 
 void MyCopiedNetworkElementsPaster::pasteEdges() {
@@ -72,7 +73,7 @@ const QPointF MyCopiedNetworkElementsPaster::calculateElementsCenter() {
     qreal numberOfCopiedNodes = 0;
     for (MyNetworkElementBase* copiedElement : _copiedNetworkElements) {
         if (copiedElement->type() == MyNetworkElementBase::NODE_ELEMENT) {
-            elementsCenter += ((MyNodeBase*)copiedElement)->position();
+            elementsCenter += ((MyNodeBase*)copiedElement)->getPosition();
             ++ numberOfCopiedNodes;
         }
     }

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -154,12 +154,12 @@ void MyEdgeBase::enableSelectEdgeMode() {
         arrowHead()->enableSelectEdgeMode();
 }
 
-const bool MyEdgeBase::canBeMovedExternally() {
+const bool MyEdgeBase::canBeMoved() {
     return false;
 }
 
-void MyEdgeBase::moveExternally(const qreal& dx, const qreal& dy) {
-    if (canBeMovedExternally())
+void MyEdgeBase::move(const qreal& dx, const qreal& dy) {
+    if (canBeMoved())
         return;
 }
 

--- a/src/negui_edge.cpp
+++ b/src/negui_edge.cpp
@@ -303,7 +303,7 @@ const bool MyConnectedToSourceCentroidNodeEdge::isCuttable() {
 
 
 const QPointF MyConnectedToSourceCentroidNodeEdge::nonCentroidNodePosition() {
-    return ((MyNodeBase*)targetNode())->getExtents().center();
+    return ((MyNodeBase*)targetNode())->getPosition();
 }
 
 MyNetworkElementBase* MyConnectedToSourceCentroidNodeEdge::nonCentroidNodeParent() {
@@ -338,7 +338,7 @@ const bool MyConnectedToTargetCentroidNodeEdge::isCuttable() {
 }
 
 const QPointF MyConnectedToTargetCentroidNodeEdge::nonCentroidNodePosition() {
-    return ((MyNodeBase*)sourceNode())->getExtents().center();
+    return ((MyNodeBase*)sourceNode())->getPosition();
 }
 
 MyNetworkElementBase* MyConnectedToTargetCentroidNodeEdge::nonCentroidNodeParent() {

--- a/src/negui_edge.h
+++ b/src/negui_edge.h
@@ -63,9 +63,9 @@ public:
     
     void enableSelectEdgeMode() override;
 
-    const bool canBeMovedExternally() override;
+    const bool canBeMoved() override;
 
-    void moveExternally(const qreal& dx, const qreal& dy) override;
+    void move(const qreal& dx, const qreal& dy) override;
     
     const QRectF getExtents() override;
     

--- a/src/negui_ellipse_graphics_item.cpp
+++ b/src/negui_ellipse_graphics_item.cpp
@@ -41,10 +41,10 @@ void MyEllipseGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 void MyEllipseGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // center-x
-        ((MyEllipseStyleBase*)style())->setCenterX(0.5 * extents.width() + extents.x() - _originalPosition.x());
+        ((MyEllipseStyleBase*)style())->setCenterX(0.5 * extents.width() + extents.x() - _originalPosition.x() + _movedOriginalPosition.x());
         
         // center-y
-        ((MyEllipseStyleBase*)style())->setCenterY(0.5 * extents.height() + extents.y() - _originalPosition.y());
+        ((MyEllipseStyleBase*)style())->setCenterY(0.5 * extents.height() + extents.y() - _originalPosition.y() + _movedOriginalPosition.y());
         
         // radius-x
         ((MyEllipseStyleBase*)style())->setRadiusX(0.5 * extents.width());
@@ -57,14 +57,13 @@ void MyEllipseGraphicsItem::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyEllipseGraphicsItem::getExtents() {
-    return QRectF(((MyEllipseStyleBase*)style())->centerX() - ((MyEllipseStyleBase*)style())->radiusX() + _originalPosition.x(),
-                  ((MyEllipseStyleBase*)style())->centerY() - ((MyEllipseStyleBase*)style())->radiusY() + _originalPosition.y(),
+    return QRectF(((MyEllipseStyleBase*)style())->centerX() - ((MyEllipseStyleBase*)style())->radiusX() + _originalPosition.x() + _movedOriginalPosition.x(),
+                  ((MyEllipseStyleBase*)style())->centerY() - ((MyEllipseStyleBase*)style())->radiusY() + _originalPosition.y() + _movedOriginalPosition.y(),
                   2 * ((MyEllipseStyleBase*)style())->radiusX(), 2 * ((MyEllipseStyleBase*)style())->radiusY());
 }
 
 void MyEllipseGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
-    _originalPosition += QPointF(dx, dy);
-    My2DShapeGraphicsItemBase::updateExtents();
+    _movedOriginalPosition += QPointF(dx, dy);
 }
 
 QGraphicsItem* MyEllipseGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_ellipse_graphics_item.cpp
+++ b/src/negui_ellipse_graphics_item.cpp
@@ -41,10 +41,10 @@ void MyEllipseGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 void MyEllipseGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // center-x
-        ((MyEllipseStyleBase*)style())->setCenterX(0.5 * extents.width() + extents.x() - (movedDistance().x() + _originalPosition.x()));
+        ((MyEllipseStyleBase*)style())->setCenterX(0.5 * extents.width() + extents.x() - _originalPosition.x());
         
         // center-y
-        ((MyEllipseStyleBase*)style())->setCenterY(0.5 * extents.height() + extents.y() - (movedDistance().y() + _originalPosition.y()));
+        ((MyEllipseStyleBase*)style())->setCenterY(0.5 * extents.height() + extents.y() - _originalPosition.y());
         
         // radius-x
         ((MyEllipseStyleBase*)style())->setRadiusX(0.5 * extents.width());
@@ -57,15 +57,14 @@ void MyEllipseGraphicsItem::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyEllipseGraphicsItem::getExtents() {
-    return QRectF(((MyEllipseStyleBase*)style())->centerX() - ((MyEllipseStyleBase*)style())->radiusX() + (movedDistance().x() + _originalPosition.x()),
-                  ((MyEllipseStyleBase*)style())->centerY() - ((MyEllipseStyleBase*)style())->radiusY() + (movedDistance().y() + _originalPosition.y()),
+    return QRectF(((MyEllipseStyleBase*)style())->centerX() - ((MyEllipseStyleBase*)style())->radiusX() + _originalPosition.x(),
+                  ((MyEllipseStyleBase*)style())->centerY() - ((MyEllipseStyleBase*)style())->radiusY() + _originalPosition.y(),
                   2 * ((MyEllipseStyleBase*)style())->radiusX(), 2 * ((MyEllipseStyleBase*)style())->radiusY());
 }
 
-void MyEllipseGraphicsItem::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
-    ((MyEllipseStyleBase*)style())->setCenterX(((MyEllipseStyleBase*)style())->centerX() - originalPositionMovedDistance.x());
-    ((MyEllipseStyleBase*)style())->setCenterY(((MyEllipseStyleBase*)style())->centerY() - originalPositionMovedDistance.y());
-    _originalPosition += originalPositionMovedDistance;
+void MyEllipseGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
+    _originalPosition += QPointF(dx, dy);
+    My2DShapeGraphicsItemBase::updateExtents();
 }
 
 QGraphicsItem* MyEllipseGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_ellipse_graphics_item.cpp
+++ b/src/negui_ellipse_graphics_item.cpp
@@ -41,10 +41,10 @@ void MyEllipseGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 void MyEllipseGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // center-x
-        ((MyEllipseStyleBase*)style())->setCenterX(0.5 * extents.width() + extents.x() - _originalPosition.x() + _movedOriginalPosition.x());
+        ((MyEllipseStyleBase*)style())->setCenterX(0.5 * extents.width() + extents.x() - (_originalPosition.x() + _movedOriginalPosition.x()));
         
         // center-y
-        ((MyEllipseStyleBase*)style())->setCenterY(0.5 * extents.height() + extents.y() - _originalPosition.y() + _movedOriginalPosition.y());
+        ((MyEllipseStyleBase*)style())->setCenterY(0.5 * extents.height() + extents.y() - (_originalPosition.y() + _movedOriginalPosition.y()));
         
         // radius-x
         ((MyEllipseStyleBase*)style())->setRadiusX(0.5 * extents.width());
@@ -57,9 +57,16 @@ void MyEllipseGraphicsItem::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyEllipseGraphicsItem::getExtents() {
-    return QRectF(((MyEllipseStyleBase*)style())->centerX() - ((MyEllipseStyleBase*)style())->radiusX() + _originalPosition.x() + _movedOriginalPosition.x(),
-                  ((MyEllipseStyleBase*)style())->centerY() - ((MyEllipseStyleBase*)style())->radiusY() + _originalPosition.y() + _movedOriginalPosition.y(),
+    return QRectF(((MyEllipseStyleBase*)style())->centerX() + _originalPosition.x() + _movedOriginalPosition.x() - ((MyEllipseStyleBase*)style())->radiusX(),
+                  ((MyEllipseStyleBase*)style())->centerY() + _originalPosition.y() + _movedOriginalPosition.y() - ((MyEllipseStyleBase*)style())->radiusY(),
                   2 * ((MyEllipseStyleBase*)style())->radiusX(), 2 * ((MyEllipseStyleBase*)style())->radiusY());
+}
+
+void MyEllipseGraphicsItem::updateOriginalPosition(const QPointF originalPosition) {
+    QRectF extents = getExtents();
+    ((MyEllipseStyleBase*)style())->setCenterX(((MyEllipseStyleBase*)style())->centerX() - (originalPosition - (_originalPosition + _movedOriginalPosition)).x());
+    ((MyEllipseStyleBase*)style())->setCenterY(((MyEllipseStyleBase*)style())->centerY() - (originalPosition - (_originalPosition + _movedOriginalPosition)).y());
+    _originalPosition = originalPosition - _movedOriginalPosition;
 }
 
 void MyEllipseGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {

--- a/src/negui_ellipse_graphics_item.h
+++ b/src/negui_ellipse_graphics_item.h
@@ -20,6 +20,8 @@ public:
     
     void setZValue(qreal z) override;
 
+    void updateOriginalPosition(const QPointF originalPosition) override;
+
     void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:

--- a/src/negui_ellipse_graphics_item.h
+++ b/src/negui_ellipse_graphics_item.h
@@ -19,8 +19,8 @@ public:
     QGraphicsItem* getFocusedGraphicsItem() override;
     
     void setZValue(qreal z) override;
-    
-    void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) override;
+
+    void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:
     void updateExtents(const QRectF& extents) override;

--- a/src/negui_network_element_aligner.cpp
+++ b/src/negui_network_element_aligner.cpp
@@ -28,7 +28,7 @@ void MyNodeAlignerBase::extractExtents() {
     _maxY = INT_MIN;
     QPointF position;
     for (MyNetworkElementBase* node : _networkElements) {
-            position = ((MyNodeBase*)node)->position();
+            position = ((MyNodeBase*)node)->getPosition();
             if (_minX > position.x())
                 _minX = position.x();
             if (_maxX < position.x())
@@ -75,7 +75,7 @@ MyNodeTopAligner::MyNodeTopAligner(QList<MyNetworkElementBase*> networkElements)
 void MyNodeTopAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0, _minY - ((MyNodeBase*)classicNode)->position().y());
+        ((MyNodeBase*)classicNode)->moveExternally(0, _minY - ((MyNodeBase*)classicNode)->getPosition().y());
     adjustCentroidNodePositions();
 }
 
@@ -88,7 +88,7 @@ MyNodeMiddleAligner::MyNodeMiddleAligner(QList<MyNetworkElementBase*> networkEle
 void MyNodeMiddleAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0, 0.5 * (_minY + _maxY) - ((MyNodeBase*)classicNode)->position().y());
+        ((MyNodeBase*)classicNode)->moveExternally(0, 0.5 * (_minY + _maxY) - ((MyNodeBase*)classicNode)->getPosition().y());
     adjustCentroidNodePositions();
 }
 
@@ -101,7 +101,7 @@ MyNodeBottomAligner::MyNodeBottomAligner(QList<MyNetworkElementBase*> networkEle
 void MyNodeBottomAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0, _maxY - ((MyNodeBase*)classicNode)->position().y());
+        ((MyNodeBase*)classicNode)->moveExternally(0, _maxY - ((MyNodeBase*)classicNode)->getPosition().y());
     adjustCentroidNodePositions();
 }
 
@@ -114,7 +114,7 @@ MyNodeLeftAligner::MyNodeLeftAligner(QList<MyNetworkElementBase*> networkElement
 void MyNodeLeftAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(_minX - ((MyNodeBase*)classicNode)->position().x(), 0);
+        ((MyNodeBase*)classicNode)->moveExternally(_minX - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
     adjustCentroidNodePositions();
 }
 
@@ -127,7 +127,7 @@ MyNodeCenterAligner::MyNodeCenterAligner(QList<MyNetworkElementBase*> networkEle
 void MyNodeCenterAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0.5 * (_minX + _maxX) - ((MyNodeBase*)classicNode)->position().x(), 0);
+        ((MyNodeBase*)classicNode)->moveExternally(0.5 * (_minX + _maxX) - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
     adjustCentroidNodePositions();
 }
 
@@ -140,7 +140,7 @@ MyNodeRightAligner::MyNodeRightAligner(QList<MyNetworkElementBase*> networkEleme
 void MyNodeRightAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(_maxX - ((MyNodeBase*)classicNode)->position().x(), 0);
+        ((MyNodeBase*)classicNode)->moveExternally(_maxX - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
     adjustCentroidNodePositions();
 }
 
@@ -160,7 +160,7 @@ void MyNodeHorizontallyDistributeAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     qreal distributionDistance = (_maxX - _minX) / (classicNodes.size() - 1);
     for (unsigned  int i = 0; i < classicNodes.size(); i++)
-        ((MyNodeBase*)classicNodes.at(i))->moveExternally(_minX - ((MyNodeBase*)classicNodes.at(i))->position().x() + i * distributionDistance, 0);
+        ((MyNodeBase*)classicNodes.at(i))->moveExternally(_minX - ((MyNodeBase*)classicNodes.at(i))->getPosition().x() + i * distributionDistance, 0);
     adjustCentroidNodePositions();
 }
 
@@ -174,7 +174,7 @@ void MyNodeVerticallyDistributeAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     qreal distributionDistance = (_maxY - _minY) / (classicNodes.size() - 1);
     for (unsigned  int i = 0; i < classicNodes.size(); i++)
-        ((MyNodeBase*)classicNodes.at(i))->moveExternally(0, _minY - ((MyNodeBase*)classicNodes.at(i))->position().y() + i * distributionDistance);
+        ((MyNodeBase*)classicNodes.at(i))->moveExternally(0, _minY - ((MyNodeBase*)classicNodes.at(i))->getPosition().y() + i * distributionDistance);
     adjustCentroidNodePositions();
 }
 
@@ -210,9 +210,10 @@ void MyNodeGridDistributeAligner::adjustClassicNodesPositionsInGrid(QList<MyNetw
     qint32 row = 0;
     while (row <= classicNodes.size() / numberOfGridColumns) {
         for (unsigned int column = 0; column < numberOfGridColumns && row * numberOfGridColumns + column < classicNodes.size()  ; column++) {
+            QPointF position = ((MyNodeBase *) classicNodes.at(row * numberOfGridColumns + column))->getPosition();
             ((MyNodeBase *) classicNodes.at(row * numberOfGridColumns + column))->moveExternally(
-                    _minX - ((MyNodeBase *) classicNodes.at(row * numberOfGridColumns + column))->position().x() +
-                    column * distributionDistance, _minY - ((MyNodeBase *) classicNodes.at(row * numberOfGridColumns + column))->position().y() + row * distributionDistance);
+                    _minX - position.x() +
+                    column * distributionDistance, _minY - position.y() + row * distributionDistance);
         }
         row++;
     }

--- a/src/negui_network_element_aligner.cpp
+++ b/src/negui_network_element_aligner.cpp
@@ -75,7 +75,7 @@ MyNodeTopAligner::MyNodeTopAligner(QList<MyNetworkElementBase*> networkElements)
 void MyNodeTopAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0, _minY - ((MyNodeBase*)classicNode)->getPosition().y());
+        ((MyNodeBase*)classicNode)->move(0, _minY - ((MyNodeBase*)classicNode)->getPosition().y());
     adjustCentroidNodePositions();
 }
 
@@ -88,7 +88,7 @@ MyNodeMiddleAligner::MyNodeMiddleAligner(QList<MyNetworkElementBase*> networkEle
 void MyNodeMiddleAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0, 0.5 * (_minY + _maxY) - ((MyNodeBase*)classicNode)->getPosition().y());
+        ((MyNodeBase*)classicNode)->move(0, 0.5 * (_minY + _maxY) - ((MyNodeBase*)classicNode)->getPosition().y());
     adjustCentroidNodePositions();
 }
 
@@ -101,7 +101,7 @@ MyNodeBottomAligner::MyNodeBottomAligner(QList<MyNetworkElementBase*> networkEle
 void MyNodeBottomAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0, _maxY - ((MyNodeBase*)classicNode)->getPosition().y());
+        ((MyNodeBase*)classicNode)->move(0, _maxY - ((MyNodeBase*)classicNode)->getPosition().y());
     adjustCentroidNodePositions();
 }
 
@@ -114,7 +114,7 @@ MyNodeLeftAligner::MyNodeLeftAligner(QList<MyNetworkElementBase*> networkElement
 void MyNodeLeftAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(_minX - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
+        ((MyNodeBase*)classicNode)->move(_minX - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
     adjustCentroidNodePositions();
 }
 
@@ -127,7 +127,7 @@ MyNodeCenterAligner::MyNodeCenterAligner(QList<MyNetworkElementBase*> networkEle
 void MyNodeCenterAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(0.5 * (_minX + _maxX) - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
+        ((MyNodeBase*)classicNode)->move(0.5 * (_minX + _maxX) - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
     adjustCentroidNodePositions();
 }
 
@@ -140,7 +140,7 @@ MyNodeRightAligner::MyNodeRightAligner(QList<MyNetworkElementBase*> networkEleme
 void MyNodeRightAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     for (MyNetworkElementBase* classicNode : classicNodes)
-        ((MyNodeBase*)classicNode)->moveExternally(_maxX - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
+        ((MyNodeBase*)classicNode)->move(_maxX - ((MyNodeBase*)classicNode)->getPosition().x(), 0);
     adjustCentroidNodePositions();
 }
 
@@ -160,7 +160,7 @@ void MyNodeHorizontallyDistributeAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     qreal distributionDistance = (_maxX - _minX) / (classicNodes.size() - 1);
     for (unsigned  int i = 0; i < classicNodes.size(); i++)
-        ((MyNodeBase*)classicNodes.at(i))->moveExternally(_minX - ((MyNodeBase*)classicNodes.at(i))->getPosition().x() + i * distributionDistance, 0);
+        ((MyNodeBase*)classicNodes.at(i))->move(_minX - ((MyNodeBase*)classicNodes.at(i))->getPosition().x() + i * distributionDistance, 0);
     adjustCentroidNodePositions();
 }
 
@@ -174,7 +174,7 @@ void MyNodeVerticallyDistributeAligner::adjustNodePositions() {
     QList<MyNetworkElementBase*> classicNodes = getClassicNodes();
     qreal distributionDistance = (_maxY - _minY) / (classicNodes.size() - 1);
     for (unsigned  int i = 0; i < classicNodes.size(); i++)
-        ((MyNodeBase*)classicNodes.at(i))->moveExternally(0, _minY - ((MyNodeBase*)classicNodes.at(i))->getPosition().y() + i * distributionDistance);
+        ((MyNodeBase*)classicNodes.at(i))->move(0, _minY - ((MyNodeBase*)classicNodes.at(i))->getPosition().y() + i * distributionDistance);
     adjustCentroidNodePositions();
 }
 
@@ -211,7 +211,7 @@ void MyNodeGridDistributeAligner::adjustClassicNodesPositionsInGrid(QList<MyNetw
     while (row <= classicNodes.size() / numberOfGridColumns) {
         for (unsigned int column = 0; column < numberOfGridColumns && row * numberOfGridColumns + column < classicNodes.size()  ; column++) {
             QPointF position = ((MyNodeBase *) classicNodes.at(row * numberOfGridColumns + column))->getPosition();
-            ((MyNodeBase *) classicNodes.at(row * numberOfGridColumns + column))->moveExternally(
+            ((MyNodeBase *) classicNodes.at(row * numberOfGridColumns + column))->move(
                     _minX - position.x() +
                     column * distributionDistance, _minY - position.y() + row * distributionDistance);
         }

--- a/src/negui_network_element_base.h
+++ b/src/negui_network_element_base.h
@@ -63,9 +63,9 @@ public:
     
     virtual const QRectF getExtents() = 0;
 
-    virtual const bool canBeMovedExternally() = 0;
+    virtual const bool canBeMoved() = 0;
 
-    virtual void moveExternally(const qreal& dx, const qreal& dy) = 0;
+    virtual void move(const qreal& dx, const qreal& dy) = 0;
     
     virtual QWidget* getFeatureMenu();
 

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -14,6 +14,7 @@ MyNetworkElementGraphicsItemBase::MyNetworkElementGraphicsItemBase(QGraphicsItem
 }
 
 void MyNetworkElementGraphicsItemBase::update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) {
+    setPos(0, 0);
     clear();
     addShapeItems(shapeStyles, zValue);
 }
@@ -193,10 +194,8 @@ void MyNetworkElementGraphicsItemBase::setSelectedWithFillColor(const bool& sele
 }
 
 void MyNetworkElementGraphicsItemBase::setFocused(const bool& isFocused) {
-    if (!isFocused) {
+    if (!isFocused)
         clearFocusedGraphicsItems();
-        update(getShapeStyles(), zValue());
-    }
     else if (!_focusedGraphicsItems.size())
         addFocusedGraphicsItems();
 }

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -14,8 +14,6 @@ MyNetworkElementGraphicsItemBase::MyNetworkElementGraphicsItemBase(QGraphicsItem
 }
 
 void MyNetworkElementGraphicsItemBase::update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) {
-    _originalPosition += pos();
-    setPos(0.0, 0.0);
     clear();
     addShapeItems(shapeStyles, zValue);
 }
@@ -30,7 +28,6 @@ void MyNetworkElementGraphicsItemBase::addShapeItems(QList<MyShapeStyleBase*> sh
 void MyNetworkElementGraphicsItemBase::addShapeItem(MyShapeStyleBase* style) {
     MyShapeGraphicsItemBase* item = createShapeGraphicsItem(style);
     if (item) {
-
         item->setStyle(style);
         item->updateStyle();
         QGraphicsItem* casted_item = dynamic_cast<QGraphicsItem*>(item);
@@ -196,8 +193,10 @@ void MyNetworkElementGraphicsItemBase::setSelectedWithFillColor(const bool& sele
 }
 
 void MyNetworkElementGraphicsItemBase::setFocused(const bool& isFocused) {
-    if (!isFocused)
+    if (!isFocused) {
         clearFocusedGraphicsItems();
+        update(getShapeStyles(), zValue());
+    }
     else if (!_focusedGraphicsItems.size())
         addFocusedGraphicsItems();
 }

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -14,8 +14,6 @@ MyNetworkElementGraphicsItemBase::MyNetworkElementGraphicsItemBase(QGraphicsItem
 }
 
 void MyNetworkElementGraphicsItemBase::update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) {
-    _originalPosition += pos();
-    setPos(0, 0);
     clear();
     addShapeItems(shapeStyles, zValue);
 }

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -14,6 +14,7 @@ MyNetworkElementGraphicsItemBase::MyNetworkElementGraphicsItemBase(QGraphicsItem
 }
 
 void MyNetworkElementGraphicsItemBase::update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) {
+    _originalPosition += pos();
     setPos(0, 0);
     clear();
     addShapeItems(shapeStyles, zValue);

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -15,7 +15,7 @@ public:
     
     MyNetworkElementGraphicsItemBase(QGraphicsItem *parent = nullptr);
     
-    void update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue);
+    virtual void update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue);
     
     void addShapeItems(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue = 0);
     

--- a/src/negui_network_element_mover.cpp
+++ b/src/negui_network_element_mover.cpp
@@ -15,5 +15,5 @@ MyNodeMover::MyNodeMover(QList<MyNetworkElementBase*> networkElements) : MyNetwo
 
 void MyNodeMover::move(const qreal& dx, const qreal& dy) {
     for (MyNetworkElementBase* networkElement : _networkElements)
-        ((MyNodeBase*)networkElement)->moveExternally(dx, dy);
+        ((MyNodeBase*)networkElement)->move(dx, dy);
 }

--- a/src/negui_network_element_mover.cpp
+++ b/src/negui_network_element_mover.cpp
@@ -14,6 +14,12 @@ MyNodeMover::MyNodeMover(QList<MyNetworkElementBase*> networkElements) : MyNetwo
 }
 
 void MyNodeMover::move(const qreal& dx, const qreal& dy) {
-    for (MyNetworkElementBase* networkElement : _networkElements)
-        ((MyNodeBase*)networkElement)->move(dx, dy);
+    for (MyNetworkElementBase* networkElement : _networkElements) {
+        if (!whetherParentNodeIsInSelectedNetworkElements(networkElement))
+            ((MyNodeBase*)networkElement)->move(dx, dy);
+    }
+}
+
+const bool MyNodeMover::whetherParentNodeIsInSelectedNetworkElements(MyNetworkElementBase* networkElement) {
+    return findElement(_networkElements, ((MyNodeBase*)networkElement)->parentNodeId());
 }

--- a/src/negui_network_element_mover.cpp
+++ b/src/negui_network_element_mover.cpp
@@ -3,20 +3,17 @@
 
 // MyNetworkElementMoverBase
 
-MyNetworkElementMoverBase::MyNetworkElementMoverBase(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement) {
+MyNetworkElementMoverBase::MyNetworkElementMoverBase(QList<MyNetworkElementBase*> networkElements) {
     _networkElements = networkElements;
-    _movedNetworkElement = movedNetworkElement;
 }
 
 // MyNodeMover
 
-MyNodeMover::MyNodeMover(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement) : MyNetworkElementMoverBase(networkElements, movedNetworkElement) {
+MyNodeMover::MyNodeMover(QList<MyNetworkElementBase*> networkElements) : MyNetworkElementMoverBase(networkElements) {
 
 }
 
 void MyNodeMover::move(const qreal& dx, const qreal& dy) {
-    for (MyNetworkElementBase* networkElement : _networkElements) {
-        if (networkElement != _movedNetworkElement)
-            ((MyNodeBase*)networkElement)->moveExternally(dx, dy);
-    }
+    for (MyNetworkElementBase* networkElement : _networkElements)
+        ((MyNodeBase*)networkElement)->moveExternally(dx, dy);
 }

--- a/src/negui_network_element_mover.h
+++ b/src/negui_network_element_mover.h
@@ -8,14 +8,13 @@ class MyNetworkElementMoverBase : public QObject {
 
 public:
 
-    MyNetworkElementMoverBase(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement);
+    MyNetworkElementMoverBase(QList<MyNetworkElementBase*> networkElements);
 
     virtual void move(const qreal& dx, const qreal& dy) = 0;
 
 protected:
 
     QList<MyNetworkElementBase*> _networkElements;
-    MyNetworkElementBase* _movedNetworkElement;
 };
 
 class MyNodeMover : public MyNetworkElementMoverBase {
@@ -23,7 +22,7 @@ class MyNodeMover : public MyNetworkElementMoverBase {
 
 public:
 
-    MyNodeMover(QList<MyNetworkElementBase*> networkElements, MyNetworkElementBase* movedNetworkElement);
+    MyNodeMover(QList<MyNetworkElementBase*> networkElements);
 
     void move(const qreal& dx, const qreal& dy) override;
 

--- a/src/negui_network_element_mover.h
+++ b/src/negui_network_element_mover.h
@@ -26,6 +26,8 @@ public:
 
     void move(const qreal& dx, const qreal& dy) override;
 
+    const bool whetherParentNodeIsInSelectedNetworkElements(MyNetworkElementBase* networkElement);
+
 };
 
 #endif

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -418,7 +418,7 @@ void MyNetworkManager::addNode(MyNetworkElementBase* n) {
         connect(n, &MyNetworkElementBase::askForWhetherAnyOtherElementsAreSelected, this, [this] (QList<MyNetworkElementBase*> networkElements) {
             return ((MyNetworkElementSelector*)_networkElementSelector)->areAnyOtherElementsSelected(networkElements); });
         connect(n, SIGNAL(askForIconsDirectoryPath()), this, SIGNAL(askForIconsDirectoryPath()));
-        connect(n, SIGNAL(positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&)), this, SLOT(moveSelectedNetworkElements(MyNetworkElementBase*, const QPointF&)));
+        connect(n, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(moveSelectedNetworkElements(const QPointF&)));
         connect(n, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)), this, SIGNAL(askForDisplaySceneContextMenu(const QPointF&)));
         connect(n, SIGNAL(askForWhetherControlModifierIsPressed()), this, SIGNAL(askForWhetherControlModifierIsPressed()));
         connect(n->graphicsItem(), SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
@@ -561,8 +561,8 @@ void MyNetworkManager::deleteEdge(MyNetworkElementBase* edge) {
     askForCreateChangeStageCommand();
 }
 
-void MyNetworkManager::moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance) {
-    MyNetworkElementMoverBase* nodeMover = new MyNodeMover(getSelectedNodes(), movedNode);
+void MyNetworkManager::moveSelectedNetworkElements(const QPointF& movedDistance) {
+    MyNetworkElementMoverBase* nodeMover = new MyNodeMover(getSelectedNodes());
     nodeMover->move(movedDistance.x(), movedDistance.y());
     nodeMover->deleteLater();
 }

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -243,7 +243,7 @@ signals:
 
 public slots:
 
-    void moveSelectedNetworkElements(MyNetworkElementBase* movedNode, const QPointF& movedDistance);
+    void moveSelectedNetworkElements(const QPointF& movedDistance);
 
 protected:
 

--- a/src/negui_new_edge_builder.cpp
+++ b/src/negui_new_edge_builder.cpp
@@ -151,7 +151,7 @@ MyNetworkElementBase* MyNewTemplateBuilder::intermediaryNode() {
 const QPointF MyNewTemplateBuilder::intermediaryNodePosition() {
     QPointF position(0.0, 0.0);
     for (MyNetworkElementBase* connectedNode : selectedEdgeSourceNodes() + selectedEdgeTargetNodes())
-        position += ((MyNodeBase*)connectedNode)->position();
+        position += ((MyNodeBase*)connectedNode)->getPosition();
     position /= selectedEdgeSourceNodes().size() + selectedEdgeTargetNodes().size();
     
     return position;

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -183,6 +183,13 @@ const QRectF MyNodeBase::getExtents() {
     return ((MyNodeSceneGraphicsItemBase*)graphicsItem())->getExtents();
 }
 
+const bool MyNodeBase::canBeMovedExternally() {
+    if (getSceneMode() == NORMAL_MODE)
+        return true;
+
+    return false;
+}
+
 const qreal MyNodeBase::endEdgePadding() {
     return  _endEdgePadding;
 }
@@ -323,21 +330,6 @@ void MyClassicNodeBase::moveExternally(const qreal& dx, const qreal& dy) {
     }
     resetPosition();
     updateFocusedGraphicsItems();
-}
-
-const bool MyClassicNodeBase::canBeMovedExternally() {
-    if (getSceneMode() == NORMAL_MODE) {
-        if (childNodes().size()) {
-            for (MyNetworkElementBase* childNode : qAsConst(childNodes())) {
-                if (childNode->isSelected())
-                    return false;
-            }
-        }
-
-        return true;
-    }
-
-    return false;
 }
 
 const QRectF MyClassicNodeBase::getExtents() {
@@ -601,15 +593,7 @@ void MyCentroidNode::setSelected(const bool& selected) {
 }
 
 void MyCentroidNode::moveExternally(const qreal& dx, const qreal& dy) {
-    if (canBeMovedExternally())
-        return;
-}
 
-const bool MyCentroidNode::canBeMovedExternally() {
-    if (getSceneMode() == NORMAL_MODE)
-        return false;
-
-    return false;
 }
 
 QWidget* MyCentroidNode::getFeatureMenu() {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -157,7 +157,7 @@ void MyNodeBase::lockParentNode(const bool& locked) {
 }
 
 const QPointF MyNodeBase::getPosition() {
-    return ((MyNodeSceneGraphicsItemBase*)graphicsItem())->getExtents().center();
+    return getExtents().center();
 }
 
 void MyNodeBase::resetPosition() {

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -315,6 +315,7 @@ void MyClassicNodeBase::adjustParentExtents() {
 }
 
 const QRectF MyClassicNodeBase::getExtents() {
+    ((MyNodeSceneGraphicsItemBase*)_graphicsItem)->updateOriginalPosition();
     if (childNodes().size()) {
         QRectF childExtents = ((MyNodeBase*)childNodes().at(0))->getExtents();
         qreal extentsX = childExtents.x();

--- a/src/negui_node.cpp
+++ b/src/negui_node.cpp
@@ -305,8 +305,9 @@ void MyClassicNodeBase::resetPosition() {
     if (!areChildNodesLocked()) {
         for (MyNetworkElementBase* node : qAsConst(childNodes())) {
             ((MyNodeBase*)node)->lockParentNode(true);
-            ((MyNodeSceneGraphicsItemBase*)node->graphicsItem())->moveBy((position - _position).x(), (position - _position).y());
+            ((MyNodeSceneGraphicsItemBase*)node->graphicsItem())->move((position - _position).x(), (position - _position).y());
             ((MyNodeBase*)node)->adjustConnectedEdges(true);
+            ((MyNodeBase*)node)->resetPosition();
         }
     }
     else
@@ -317,7 +318,7 @@ void MyClassicNodeBase::resetPosition() {
 
 void MyClassicNodeBase::moveExternally(const qreal& dx, const qreal& dy) {
     if (canBeMovedExternally()) {
-        ((MyNodeSceneGraphicsItemBase*)(graphicsItem()))->moveBy(dx, dy);
+        ((MyNodeSceneGraphicsItemBase*)(graphicsItem()))->move(dx, dy);
         adjustConnectedEdges();
     }
     resetPosition();
@@ -387,7 +388,7 @@ const QRectF MyClassicNodeBase::createParentNodeExtentsRectangle(qreal extentsX,
 void MyClassicNodeBase::adjustExtents() {
     QRectF extents = getExtents();
     QPointF position = getPosition();
-    ((MyClassicNodeSceneGraphicsItemBase*)graphicsItem())->moveBy(extents.x() - (position.x() - 0.5 * extents.width()), extents.y() - (position.y() - 0.5 * extents.height()));
+    ((MyClassicNodeSceneGraphicsItemBase*)graphicsItem())->move(extents.x() - (position.x() - 0.5 * extents.width()), extents.y() - (position.y() - 0.5 * extents.height()));
     ((MyClassicNodeSceneGraphicsItemBase*)graphicsItem())->updateExtents(extents);
 }
 
@@ -530,8 +531,9 @@ void MyCentroidNode::adjustNodePositionToNeighborNodes(const bool& movedByParent
         if (isNodePositionConnectedToNeighborNodes() && edges().size()) {
             QPointF oldPosition = getPosition();
             QPointF updatedPosition = getNodeUpdatedPositionUsingConnectedEdges();
-            ((MyCentroidNodeSceneGraphicsItem *) graphicsItem())->moveBy((updatedPosition - oldPosition).x(),
+            ((MyCentroidNodeSceneGraphicsItem *) graphicsItem())->move((updatedPosition - oldPosition).x(),
                                                                          (updatedPosition - oldPosition).y());
+            resetPosition();
             updateFocusedGraphicsItems();
             adjustConnectedBezierCurves();
         }

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -68,7 +68,7 @@ public:
 
     const QRectF getExtents() override;
 
-    const bool canBeMovedExternally() override;
+    const bool canBeMoved() override;
 
     const qreal endEdgePadding();
     
@@ -96,14 +96,13 @@ signals:
     
 public slots:
 
+    void updateConnectedEdgesPoints();
+
     void updateSelectedNodesParentNode();
-    
-    // update the parent node of the node
+
     void updateParentNode();
 
     MyNetworkElementBase* getParentNodeAtPosition(const QPointF& position);
-
-    virtual void resetPosition();
 
     void adjustConnectedEdges(const bool& movedByParentNodeMove = false);
 
@@ -115,7 +114,6 @@ protected:
     QString _parentNodeId;
     MyNetworkElementBase* _parentNode;
     QList<MyNetworkElementBase*> _edges;
-    QPointF _position;
     bool _isSetParentNode;
     bool _isParentNodeLocked;
     qreal _endEdgePadding;
@@ -145,7 +143,11 @@ public:
     // return true if the child nodes of the node are locked
     const bool areChildNodesLocked() const { return _areChildNodesLocked; }
 
-    void moveExternally(const qreal& dx, const qreal& dy) override;
+    void move(const qreal& dx, const qreal& dy) override;
+
+    void moveChildNodes(const qreal& dx, const qreal& dy);
+
+    void adjustParentExtents();
 
     // get node extents based on its children extents
     const QRectF getExtents() override;
@@ -157,8 +159,6 @@ public:
     const qint32 calculateConnectedEdgeZValue() override;
 
 public slots:
-
-    void resetPosition() override;
 
     void adjustExtents() override;
 
@@ -232,7 +232,7 @@ public:
 
     const bool connectedBezierCurvesNeedsToBeAdjusted();
 
-    void moveExternally(const qreal& dx, const qreal& dy) override;
+    void move(const qreal& dx, const qreal& dy) override;
 
     QWidget* getFeatureMenu() override;
 

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -88,7 +88,7 @@ public:
     
 signals:
 
-    void positionChangedByMouseMoveEvent(MyNetworkElementBase*, const QPointF&);
+    void positionChangedByMouseMoveEvent(const QPointF&);
 
     void parentNodeIsUpdated();
     

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -68,6 +68,8 @@ public:
 
     const QRectF getExtents() override;
 
+    const bool canBeMovedExternally() override;
+
     const qreal endEdgePadding();
     
     const qint32 calculateZValue() override;
@@ -144,8 +146,6 @@ public:
     const bool areChildNodesLocked() const { return _areChildNodesLocked; }
 
     void moveExternally(const qreal& dx, const qreal& dy) override;
-
-    const bool canBeMovedExternally() override;
 
     // get node extents based on its children extents
     const QRectF getExtents() override;
@@ -233,8 +233,6 @@ public:
     const bool connectedBezierCurvesNeedsToBeAdjusted();
 
     void moveExternally(const qreal& dx, const qreal& dy) override;
-
-    const bool canBeMovedExternally() override;
 
     QWidget* getFeatureMenu() override;
 

--- a/src/negui_node.h
+++ b/src/negui_node.h
@@ -14,7 +14,7 @@ public:
         CENTROID_NODE,
     } NODE_TYPE;
     
-    MyNodeBase(const QString& name, const qreal& x, const qreal& y);
+    MyNodeBase(const QString& name);
     
     ELEMENT_TYPE type() override;
 
@@ -40,7 +40,7 @@ public:
     const bool isCuttable() override;
 
     // get the position of the node
-    const QPointF position() const;
+    const QPointF getPosition();
 
     // get the id of parent node of the node
     const QString& parentNodeId() const;
@@ -100,12 +100,8 @@ public slots:
     void updateParentNode();
 
     MyNetworkElementBase* getParentNodeAtPosition(const QPointF& position);
-    
-    // set the position of the node using its current position
-    void resetPosition();
-    
-    // set the position of the node
-    virtual void setPosition(const QPointF& position);
+
+    virtual void resetPosition();
 
     void adjustConnectedEdges(const bool& movedByParentNodeMove = false);
 
@@ -128,7 +124,7 @@ class MyClassicNodeBase : public MyNodeBase {
 
 public:
 
-    MyClassicNodeBase(const QString& name, const qreal& x, const qreal& y);
+    MyClassicNodeBase(const QString& name);
 
     const bool isCopyable() override;
 
@@ -162,8 +158,7 @@ public:
 
 public slots:
 
-    // set the position of the node
-    void setPosition(const QPointF& position) override;
+    void resetPosition() override;
 
     void adjustExtents() override;
 

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -71,6 +71,7 @@ void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
 
 void MyNodeSceneGraphicsItemBase::move(qreal dx, qreal dy) {
     _originalPosition += QPointF(dx, dy);
+    moveBy(dx, dy);
     moveChildItems(dx, dy);
 }
 

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -24,9 +24,6 @@ QMenu* MyNodeGraphicsItemBase::createContextMenuObject() {
 
 MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position, QGraphicsItem *parent) : MyNodeGraphicsItemBase(parent) {
     _originalPosition = position;
-
-    // make it movable
-    setFlag(QGraphicsItem::ItemIsMovable, true);
     
     // make it send position changes
     setFlag(QGraphicsItem::ItemSendsScenePositionChanges, true);
@@ -39,55 +36,42 @@ MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position
     setZValue(2);
 }
 
-void MyNodeSceneGraphicsItemBase::moveChildItems(const QPointF& movedDistance) {
+void MyNodeSceneGraphicsItemBase::moveChildItems(const qreal& dx, const qreal& dy) {
     for (QGraphicsItem* item : childItems()) {
         MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
         if (casted_item)
-            casted_item->setMovedDistance(movedDistance);
+            casted_item->moveOriginalPosition(dx,dy);
     }
 }
 
 void MyNodeSceneGraphicsItemBase::enableNormalMode() {
     MyNetworkElementGraphicsItemBase::enableNormalMode();
     setCursor(Qt::PointingHandCursor);
-    setFlag(QGraphicsItem::ItemIsMovable, true);
 }
 
 void MyNodeSceneGraphicsItemBase::enableAddNodeMode() {
     MyNetworkElementGraphicsItemBase::enableAddNodeMode();
     setCursor(Qt::ArrowCursor);
-    setFlag(QGraphicsItem::ItemIsMovable, false);
 }
 
 void MyNodeSceneGraphicsItemBase::enableSelectNodeMode() {
     MyNetworkElementGraphicsItemBase::enableSelectNodeMode();
     setCursor(Qt::PointingHandCursor);
-    setFlag(QGraphicsItem::ItemIsMovable, false);
 }
 
 void MyNodeSceneGraphicsItemBase::enableAddEdgeMode() {
     MyNetworkElementGraphicsItemBase::enableAddEdgeMode();
     setCursor(Qt::PointingHandCursor);
-    setFlag(QGraphicsItem::ItemIsMovable, false);
 }
 
 void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
     MyNetworkElementGraphicsItemBase::enableSelectEdgeMode();
     setCursor(Qt::ArrowCursor);
-    setFlag(QGraphicsItem::ItemIsMovable, false);
-}
-
-QVariant MyNodeSceneGraphicsItemBase::itemChange(GraphicsItemChange change, const QVariant &value) {
-    if (change == ItemPositionChange) {
-        moveChildItems(value.toPointF());
-        emit askForResetPosition();
-    }
-
-    return QGraphicsItem::itemChange(change, value);
 }
 
 void MyNodeSceneGraphicsItemBase::moveBy(qreal dx, qreal dy) {
-    QGraphicsItem::moveBy(dx, dy);
+    _originalPosition += QPointF(dx, dy);
+    moveChildItems(dx, dy);
 }
 
 void MyNodeSceneGraphicsItemBase::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
@@ -126,30 +110,9 @@ const bool MyClassicNodeSceneGraphicsItemBase::canAddTextShape() {
 void MyClassicNodeSceneGraphicsItemBase::setFocused(const bool& isFocused) {
     if (!isFocused && _focusedGraphicsItems.size()) {
         emit askForResetPosition();
-        adjustOriginalPosition();
         emit askForCreateChangeStageCommand();
     }
     MyNetworkElementGraphicsItemBase::setFocused(isFocused);
-}
-
-void MyClassicNodeSceneGraphicsItemBase::moveBy(qreal dx, qreal dy) {
-    if (qFabs(dx) > 0.0001 || qFabs(dy) > 0.0001)
-        QGraphicsItem::moveBy(dx, dy);
-    else
-        emit askForResetPosition();
-}
-
-void MyClassicNodeSceneGraphicsItemBase::adjustOriginalPosition() {
-    // TODO leads to an error in the position for newly added shapes.
-    /*
-    QPointF extentsCenter = getExtents().center();
-    for (QGraphicsItem* item : childItems()) {
-        MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
-        if (casted_item)
-            casted_item->adjustOriginalPosition(extentsCenter - (_originalPosition + pos()));
-    }
-    _originalPosition = extentsCenter - pos();
-     */
 }
 
 void MyClassicNodeSceneGraphicsItemBase::updateExtents(const QRectF& extents) {

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -36,6 +36,23 @@ MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position
     setZValue(2);
 }
 
+void MyNodeSceneGraphicsItemBase::update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) {
+    if (_shapeStyles.size()) {
+        _originalPosition = getExtents().center();
+        setPos(0, 0);
+    }
+    MyNetworkElementGraphicsItemBase::update(shapeStyles, zValue);
+}
+
+void MyNodeSceneGraphicsItemBase::updateOriginalPosition() {
+    QPointF originalPosition = getExtents().center();
+    for (QGraphicsItem* item : childItems()) {
+        MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
+        if (casted_item)
+            casted_item->updateOriginalPosition(originalPosition);
+    }
+}
+
 void MyNodeSceneGraphicsItemBase::moveChildItems(const qreal& dx, const qreal& dy) {
     for (QGraphicsItem* item : childItems()) {
         MyShapeGraphicsItemBase* casted_item = dynamic_cast<MyShapeGraphicsItemBase*>(item);
@@ -217,7 +234,6 @@ MyCentroidNodeSceneGraphicsItem::MyCentroidNodeSceneGraphicsItem(const QPointF &
 void MyCentroidNodeSceneGraphicsItem::connectShapeGraphicsItem(MyShapeGraphicsItemBase *item) {
     connect(item, SIGNAL(askForGetBezierAdjustLine()), this, SIGNAL(askForGetBezierAdjustLine()));
     connect(item, SIGNAL(bezierAdjustLineIsUpdated(const QLineF&)), this, SIGNAL(bezierAdjustLineIsUpdated(const QLineF&)));
-
 }
 
 const bool MyCentroidNodeSceneGraphicsItem::canAddCentroidShape() {

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -69,7 +69,7 @@ void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
     setCursor(Qt::ArrowCursor);
 }
 
-void MyNodeSceneGraphicsItemBase::moveBy(qreal dx, qreal dy) {
+void MyNodeSceneGraphicsItemBase::move(qreal dx, qreal dy) {
     _originalPosition += QPointF(dx, dy);
     moveChildItems(dx, dy);
 }

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -70,7 +70,6 @@ void MyNodeSceneGraphicsItemBase::enableSelectEdgeMode() {
 }
 
 void MyNodeSceneGraphicsItemBase::move(qreal dx, qreal dy) {
-    _originalPosition += QPointF(dx, dy);
     moveBy(dx, dy);
     moveChildItems(dx, dy);
 }

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -110,7 +110,7 @@ const bool MyClassicNodeSceneGraphicsItemBase::canAddTextShape() {
 
 void MyClassicNodeSceneGraphicsItemBase::setFocused(const bool& isFocused) {
     if (!isFocused && _focusedGraphicsItems.size()) {
-        emit askForResetPosition();
+        emit askForUpdateConnectedEdgesPoints();
         emit askForCreateChangeStageCommand();
     }
     MyNetworkElementGraphicsItemBase::setFocused(isFocused);

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -48,7 +48,7 @@ signals:
     
     void askForUpdateParentNode();
     
-    void askForResetPosition();
+    void askForUpdateConnectedEdgesPoints();
 
     void positionChangedByMouseMoveEvent(const QPointF&);
     

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -30,7 +30,7 @@ public:
 
     MyNodeSceneGraphicsItemBase(const QPointF &position, QGraphicsItem *parent = nullptr);
 
-    void moveChildItems(const QPointF& movedDistance);
+    void moveChildItems(const qreal& dx, const qreal& dy);
     
     void enableNormalMode() override;
 
@@ -54,8 +54,6 @@ signals:
     
 protected:
 
-    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
 
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
@@ -77,10 +75,6 @@ public:
     const bool canAddTextShape() override;
 
     void setFocused(const bool& isFocused) override;
-
-    void moveBy(qreal dx, qreal dy) override;
-
-    void adjustOriginalPosition();
 
 public slots:
 

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -30,6 +30,8 @@ public:
 
     MyNodeSceneGraphicsItemBase(const QPointF &position, QGraphicsItem *parent = nullptr);
 
+    void update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) override;
+
     void moveChildItems(const qreal& dx, const qreal& dy);
     
     void enableNormalMode() override;
@@ -51,6 +53,10 @@ signals:
     void askForUpdateConnectedEdgesPoints();
 
     void positionChangedByMouseMoveEvent(const QPointF&);
+
+public slots:
+
+    void updateOriginalPosition();
     
 protected:
 

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -42,7 +42,7 @@ public:
 
     void enableSelectEdgeMode() override;
 
-    virtual void moveBy(qreal dx, qreal dy);
+    virtual void move(qreal dx, qreal dy);
     
 signals:
     

--- a/src/negui_polygon_graphics_item.cpp
+++ b/src/negui_polygon_graphics_item.cpp
@@ -44,15 +44,26 @@ void MyPolygonGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 
 void MyPolygonGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle())
-        ((MyPolygonStyleBase*)style())->scaleToExtents(QRectF(extents.x() - (boundingRect().x() + _movedOriginalPosition.x()),
-                                                              extents.y() - (boundingRect().y() + _movedOriginalPosition.y()), extents.width(), extents.height()));
+        ((MyPolygonStyleBase*)style())->scaleToExtents(QRectF(extents.x() - (_originalPosition.x() + _movedOriginalPosition.x()),
+                                                       extents.y() - (_originalPosition.y() + _movedOriginalPosition.y()),
+                                                       extents.width(), extents.height()));
     
     updateStyle();
 }
 
 QRectF MyPolygonGraphicsItem::getExtents() {
     QRectF polygonBoundingRect = ((MyPolygonStyleBase*)style())->getShapeExtents();
-    return QRectF(boundingRect().x() + _movedOriginalPosition.x(), boundingRect().y() + _movedOriginalPosition.y(), polygonBoundingRect.width(), polygonBoundingRect.height());
+    return QRectF(polygonBoundingRect.x() + (_originalPosition.x() + _movedOriginalPosition.x()),
+                  polygonBoundingRect.y() + (_originalPosition.y() + _movedOriginalPosition.y()),
+                  polygonBoundingRect.width(), polygonBoundingRect.height());
+}
+
+void MyPolygonGraphicsItem::updateOriginalPosition(const QPointF originalPosition) {
+    QRectF polygonBoundingRect = ((MyPolygonStyleBase*)style())->getShapeExtents();
+    ((MyPolygonStyleBase*)style())->scaleToExtents(QRectF(polygonBoundingRect.x() - (originalPosition - (_originalPosition + _movedOriginalPosition)).x(),
+                                                          polygonBoundingRect.y() - (originalPosition - (_originalPosition + _movedOriginalPosition)).y(),
+                                                          polygonBoundingRect.width(), polygonBoundingRect.height()));
+    _originalPosition = originalPosition - _movedOriginalPosition;
 }
 
 void MyPolygonGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {

--- a/src/negui_polygon_graphics_item.cpp
+++ b/src/negui_polygon_graphics_item.cpp
@@ -44,19 +44,19 @@ void MyPolygonGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 
 void MyPolygonGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle())
-        ((MyPolygonStyleBase*)style())->scaleToExtents(QRectF(extents.x() - (movedDistance().x() + boundingRect().x()), extents.y() - (movedDistance().y() + boundingRect().y()), extents.width(), extents.height()));
+        ((MyPolygonStyleBase*)style())->scaleToExtents(QRectF(extents.x() - boundingRect().x(), extents.y() - boundingRect().y(), extents.width(), extents.height()));
     
     updateStyle();
 }
 
 QRectF MyPolygonGraphicsItem::getExtents() {
     QRectF polygonBoundingRect = ((MyPolygonStyleBase*)style())->getShapeExtents();
-    return QRectF((movedDistance().x() + boundingRect().x()), (movedDistance().y() + boundingRect().y()), polygonBoundingRect.width(), polygonBoundingRect.height());
+    return QRectF(boundingRect().x(), boundingRect().y(), polygonBoundingRect.width(), polygonBoundingRect.height());
 }
 
-void MyPolygonGraphicsItem::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
-    ((MyPolygonStyleBase*)style())->moveBy(-originalPositionMovedDistance.x(), -originalPositionMovedDistance.y());
-    _originalPosition += originalPositionMovedDistance;
+void MyPolygonGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
+    _originalPosition += QPointF(dx, dy);
+    My2DShapeGraphicsItemBase::updateExtents();
 }
 
 QGraphicsItem* MyPolygonGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_polygon_graphics_item.cpp
+++ b/src/negui_polygon_graphics_item.cpp
@@ -44,19 +44,19 @@ void MyPolygonGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 
 void MyPolygonGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle())
-        ((MyPolygonStyleBase*)style())->scaleToExtents(QRectF(extents.x() - boundingRect().x(), extents.y() - boundingRect().y(), extents.width(), extents.height()));
+        ((MyPolygonStyleBase*)style())->scaleToExtents(QRectF(extents.x() - (boundingRect().x() + _movedOriginalPosition.x()),
+                                                              extents.y() - (boundingRect().y() + _movedOriginalPosition.y()), extents.width(), extents.height()));
     
     updateStyle();
 }
 
 QRectF MyPolygonGraphicsItem::getExtents() {
     QRectF polygonBoundingRect = ((MyPolygonStyleBase*)style())->getShapeExtents();
-    return QRectF(boundingRect().x(), boundingRect().y(), polygonBoundingRect.width(), polygonBoundingRect.height());
+    return QRectF(boundingRect().x() + _movedOriginalPosition.x(), boundingRect().y() + _movedOriginalPosition.y(), polygonBoundingRect.width(), polygonBoundingRect.height());
 }
 
 void MyPolygonGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
-    _originalPosition += QPointF(dx, dy);
-    My2DShapeGraphicsItemBase::updateExtents();
+    _movedOriginalPosition += QPointF(dx, dy);
 }
 
 QGraphicsItem* MyPolygonGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_polygon_graphics_item.h
+++ b/src/negui_polygon_graphics_item.h
@@ -20,6 +20,8 @@ public:
     
     void setZValue(qreal z) override;
 
+    void updateOriginalPosition(const QPointF originalPosition) override;
+
     void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:

--- a/src/negui_polygon_graphics_item.h
+++ b/src/negui_polygon_graphics_item.h
@@ -19,8 +19,8 @@ public:
     QGraphicsItem* getFocusedGraphicsItem() override;
     
     void setZValue(qreal z) override;
-    
-    void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) override;
+
+    void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:
     void updateExtents(const QRectF& extents) override;

--- a/src/negui_polygon_style.cpp
+++ b/src/negui_polygon_style.cpp
@@ -56,12 +56,13 @@ const QRectF MyPolygonStyleBase::getShapeExtents() {
         if (extents.y() + extents.height() < parameter->defaultValueY())
             extents.setHeight(parameter->defaultValueY() - extents.y());
     }
-    
+
     return extents;
 }
 
 void MyPolygonStyleBase::updateShapeExtents(const QRectF& extents) {
-    scaleToExtents(QRectF(extents.x() + 0.5 * extents.width(), extents.y() + 0.5 * extents.height(), extents.width(), extents.height()));
+    QRectF polygonBoundingRect = getShapeExtents();
+    scaleToExtents(QRectF(polygonBoundingRect.x(), polygonBoundingRect.y(), extents.width(), extents.height()));
 }
 
 void MyPolygonStyleBase::scaleToExtents(const QRectF& extents) {
@@ -71,8 +72,8 @@ void MyPolygonStyleBase::scaleToExtents(const QRectF& extents) {
     
     QList<MyAbsolutePointParameter*> parameters = pointParameters();
     for (MyAbsolutePointParameter* parameter : qAsConst(parameters)) {
-        parameter->setDefaultValueX(extents.x() + xScaleFactor * (parameter->defaultValueX() - polygonBoundingRect.center().x()) + polygonBoundingRect.center().x());
-        parameter->setDefaultValueY(extents.y() + yScaleFactor * (parameter->defaultValueY() - polygonBoundingRect.center().y()) + polygonBoundingRect.center().y());
+        parameter->setDefaultValueX(xScaleFactor * parameter->defaultValueX() + (extents.x() - polygonBoundingRect.x()));
+        parameter->setDefaultValueY(yScaleFactor * parameter->defaultValueY() + (extents.y() - polygonBoundingRect.y()));
     }
 }
 

--- a/src/negui_polygon_style.cpp
+++ b/src/negui_polygon_style.cpp
@@ -76,14 +76,6 @@ void MyPolygonStyleBase::scaleToExtents(const QRectF& extents) {
     }
 }
 
-void MyPolygonStyleBase::moveBy(qreal dx, qreal dy) {
-    QList<MyAbsolutePointParameter*> parameters = pointParameters();
-    for (MyAbsolutePointParameter* parameter : qAsConst(parameters)) {
-        parameter->setDefaultValueX(parameter->defaultValueX() + dx);
-        parameter->setDefaultValueY(parameter->defaultValueY() + dy);
-    }
-}
-
 void MyPolygonStyleBase::reset() {
     MyShapeStyleBase::reset();
     for (MyParameterBase* parameter : pointParameters())

--- a/src/negui_polygon_style.h
+++ b/src/negui_polygon_style.h
@@ -23,8 +23,6 @@ public:
     // scale the points to fit the extents
     void scaleToExtents(const QRectF& extents);
 
-    void moveBy(qreal dx, qreal dy);
-
     // add the default points for a polygon style that contains no point
     virtual void addDefaultPoints() = 0;
 

--- a/src/negui_rectangle_graphics_item.cpp
+++ b/src/negui_rectangle_graphics_item.cpp
@@ -50,10 +50,10 @@ void MyRectangleGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 void MyRectangleGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // x
-        ((MyRectangleStyleBase*)style())->setX(extents.x() - (movedDistance().x() + _originalPosition.x()));
+        ((MyRectangleStyleBase*)style())->setX(extents.x() - _originalPosition.x());
         
         // y
-        ((MyRectangleStyleBase*)style())->setY(extents.y() - (movedDistance().y() + _originalPosition.y()));
+        ((MyRectangleStyleBase*)style())->setY(extents.y() - _originalPosition.y());
         
         // border-radius-x
         ((MyRectangleStyleBase*)style())->setBorderRadiusX((extents.width()/ ((MyRectangleStyleBase*)style())->width()) * ((MyRectangleStyleBase*)style())->borderRadiusX());
@@ -72,7 +72,7 @@ void MyRectangleGraphicsItem::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyRectangleGraphicsItem::getExtents() {
-    return QRectF(((MyRectangleStyleBase*)style())->x() + (movedDistance().x() + _originalPosition.x()), ((MyRectangleStyleBase*)style())->y() + (movedDistance().y() + _originalPosition.y()), ((MyRectangleStyleBase*)style())->width(), ((MyRectangleStyleBase*)style())->height());
+    return QRectF(((MyRectangleStyleBase*)style())->x() + _originalPosition.x(), ((MyRectangleStyleBase*)style())->y() + _originalPosition.y(), ((MyRectangleStyleBase*)style())->width(), ((MyRectangleStyleBase*)style())->height());
 }
 
 void MyRectangleGraphicsItem::updateBorderRadii(const qreal& borderRadiusX, const qreal& borderRadiusY) {
@@ -87,10 +87,9 @@ void MyRectangleGraphicsItem::updateBorderRadii(const qreal& borderRadiusX, cons
     updateStyle();
 }
 
-void MyRectangleGraphicsItem::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
-    ((MyRectangleStyleBase*)style())->setX(((MyRectangleStyleBase*)style())->x() - originalPositionMovedDistance.x());
-    ((MyRectangleStyleBase*)style())->setY(((MyRectangleStyleBase*)style())->y() - originalPositionMovedDistance.y());
-    _originalPosition += originalPositionMovedDistance;
+void MyRectangleGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
+    _originalPosition += QPointF(dx, dy);
+    My2DShapeGraphicsItemBase::updateExtents();
 }
 
 QGraphicsItem* MyRectangleGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_rectangle_graphics_item.cpp
+++ b/src/negui_rectangle_graphics_item.cpp
@@ -89,6 +89,13 @@ void MyRectangleGraphicsItem::updateBorderRadii(const qreal& borderRadiusX, cons
     updateStyle();
 }
 
+void MyRectangleGraphicsItem::updateOriginalPosition(const QPointF originalPosition) {
+    QRectF extents = getExtents();
+    ((MyRectangleStyleBase*)style())->setX(((MyRectangleStyleBase*)style())->x() - (originalPosition - (_originalPosition + _movedOriginalPosition)).x());
+    ((MyRectangleStyleBase*)style())->setY(((MyRectangleStyleBase*)style())->y() - (originalPosition - (_originalPosition + _movedOriginalPosition)).y());
+    _originalPosition = originalPosition - _movedOriginalPosition;
+}
+
 void MyRectangleGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
     _movedOriginalPosition += QPointF(dx, dy);
 }

--- a/src/negui_rectangle_graphics_item.cpp
+++ b/src/negui_rectangle_graphics_item.cpp
@@ -50,10 +50,10 @@ void MyRectangleGraphicsItem::setSelectedWithFillColor(const bool& selected) {
 void MyRectangleGraphicsItem::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // x
-        ((MyRectangleStyleBase*)style())->setX(extents.x() - _originalPosition.x());
+        ((MyRectangleStyleBase*)style())->setX(extents.x() - (_originalPosition.x() + _movedOriginalPosition.x()));
         
         // y
-        ((MyRectangleStyleBase*)style())->setY(extents.y() - _originalPosition.y());
+        ((MyRectangleStyleBase*)style())->setY(extents.y() - (_originalPosition.y() + _movedOriginalPosition.y()));
         
         // border-radius-x
         ((MyRectangleStyleBase*)style())->setBorderRadiusX((extents.width()/ ((MyRectangleStyleBase*)style())->width()) * ((MyRectangleStyleBase*)style())->borderRadiusX());
@@ -72,7 +72,9 @@ void MyRectangleGraphicsItem::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyRectangleGraphicsItem::getExtents() {
-    return QRectF(((MyRectangleStyleBase*)style())->x() + _originalPosition.x(), ((MyRectangleStyleBase*)style())->y() + _originalPosition.y(), ((MyRectangleStyleBase*)style())->width(), ((MyRectangleStyleBase*)style())->height());
+    return  QRectF(((MyRectangleStyleBase*)style())->x() + _originalPosition.x() + _movedOriginalPosition.x(),
+                   ((MyRectangleStyleBase*)style())->y() + _originalPosition.y() + _movedOriginalPosition.y(),
+                   ((MyRectangleStyleBase*)style())->width(), ((MyRectangleStyleBase*)style())->height());
 }
 
 void MyRectangleGraphicsItem::updateBorderRadii(const qreal& borderRadiusX, const qreal& borderRadiusY) {
@@ -88,8 +90,7 @@ void MyRectangleGraphicsItem::updateBorderRadii(const qreal& borderRadiusX, cons
 }
 
 void MyRectangleGraphicsItem::moveOriginalPosition(const qreal& dx, const qreal& dy) {
-    _originalPosition += QPointF(dx, dy);
-    My2DShapeGraphicsItemBase::updateExtents();
+    _movedOriginalPosition += QPointF(dx, dy);
 }
 
 QGraphicsItem* MyRectangleGraphicsItem::getFocusedGraphicsItem() {

--- a/src/negui_rectangle_graphics_item.h
+++ b/src/negui_rectangle_graphics_item.h
@@ -21,8 +21,8 @@ public:
     QGraphicsItem* getFocusedGraphicsItem() override;
     
     void setZValue(qreal z) override;
-    
-    void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) override;
+
+    void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:
     void updateExtents(const QRectF& extents) override;

--- a/src/negui_rectangle_graphics_item.h
+++ b/src/negui_rectangle_graphics_item.h
@@ -22,6 +22,8 @@ public:
     
     void setZValue(qreal z) override;
 
+    void updateOriginalPosition(const QPointF originalPosition) override;
+
     void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:

--- a/src/negui_shape_graphics_item_base.cpp
+++ b/src/negui_shape_graphics_item_base.cpp
@@ -5,7 +5,6 @@
 MyShapeGraphicsItemBase::MyShapeGraphicsItemBase() {
     _style = NULL;
     _isSetStyle = false;
-    _movedDistance = QPointF(0.0, 0.0);
 }
 
 MyShapeStyleBase* MyShapeGraphicsItemBase::style() {
@@ -17,10 +16,6 @@ void MyShapeGraphicsItemBase::setStyle(MyShapeStyleBase* style) {
     _isSetStyle = true;
 }
 
-void MyShapeGraphicsItemBase::setMovedDistance(const QPointF& movedDistance) {
-    _movedDistance = movedDistance;
-}
-
-const QPointF& MyShapeGraphicsItemBase::movedDistance() const {
-    return _movedDistance;
+void MyShapeGraphicsItemBase::updateExtents() {
+    updateExtents(getExtents());
 }

--- a/src/negui_shape_graphics_item_base.h
+++ b/src/negui_shape_graphics_item_base.h
@@ -28,6 +28,8 @@ public:
     virtual QGraphicsItem* getFocusedGraphicsItem() = 0;
     
     virtual void setZValue(qreal z) = 0;
+
+    virtual void updateOriginalPosition(const QPointF originalPosition) = 0;
     
     virtual void moveOriginalPosition(const qreal& dx, const qreal& dy) = 0;
 

--- a/src/negui_shape_graphics_item_base.h
+++ b/src/negui_shape_graphics_item_base.h
@@ -17,10 +17,6 @@ public:
     
     const bool isSetStyle() const { return _isSetStyle; }
     
-    void setMovedDistance(const QPointF& movedDistance);
-    
-    const QPointF& movedDistance() const;
-    
     virtual void updateStyle() = 0;
     
     virtual void setSelectedWithBorderColor(const bool& selected) = 0;
@@ -33,13 +29,15 @@ public:
     
     virtual void setZValue(qreal z) = 0;
     
-    virtual void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) = 0;
+    virtual void moveOriginalPosition(const qreal& dx, const qreal& dy) = 0;
 
 signals:
 
     void askForAdjustFocusedGraphicsItems();
     
 public slots:
+
+    void updateExtents();
 
     virtual void updateExtents(const QRectF& extents) = 0;
 

--- a/src/negui_shape_graphics_item_base.h
+++ b/src/negui_shape_graphics_item_base.h
@@ -44,7 +44,7 @@ public slots:
 protected:
     MyShapeStyleBase* _style;
     QPointF _originalPosition;
-    QPointF _movedDistance;
+    QPointF _movedOriginalPosition;
     bool _isSetStyle;
 };
 

--- a/src/negui_text_graphics_item.cpp
+++ b/src/negui_text_graphics_item.cpp
@@ -64,6 +64,13 @@ QRectF MyTextGraphicsItemBase::getExtents() {
                   ((MyTextStyleBase*)style())->width(), ((MyTextStyleBase*)style())->height());
 }
 
+void MyTextGraphicsItemBase::updateOriginalPosition(const QPointF originalPosition) {
+    QRectF extents = getExtents();
+    ((MyTextStyleBase*)style())->setX(((MyTextStyleBase*)style())->x() - (originalPosition - (_originalPosition + _movedOriginalPosition)).x());
+    ((MyTextStyleBase*)style())->setY(((MyTextStyleBase*)style())->y() - (originalPosition - (_originalPosition + _movedOriginalPosition)).y());
+    _originalPosition = originalPosition - _movedOriginalPosition;
+}
+
 void MyTextGraphicsItemBase::moveOriginalPosition(const qreal& dx, const qreal& dy) {
     _movedOriginalPosition += QPointF(dx, dy);
 }

--- a/src/negui_text_graphics_item.cpp
+++ b/src/negui_text_graphics_item.cpp
@@ -43,10 +43,10 @@ void MyTextGraphicsItemBase::setSelectedWithFillColor(const bool& selected) {
 void MyTextGraphicsItemBase::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // x
-        ((MyTextStyleBase*)style())->setX(extents.x() - (movedDistance().x() + _originalPosition.x()));
+        ((MyTextStyleBase*)style())->setX(extents.x() - _originalPosition.x());
         
         // y
-        ((MyTextStyleBase*)style())->setY(extents.y() - (movedDistance().y() + _originalPosition.y()));
+        ((MyTextStyleBase*)style())->setY(extents.y() - _originalPosition.y());
         
         // width
         ((MyTextStyleBase*)style())->setWidth(extents.width());
@@ -59,13 +59,12 @@ void MyTextGraphicsItemBase::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyTextGraphicsItemBase::getExtents() {
-    return QRectF(((MyTextStyleBase*)style())->x() + (movedDistance().x() + _originalPosition.x()), ((MyTextStyleBase*)style())->y() + (movedDistance().y() + _originalPosition.y()), ((MyTextStyleBase*)style())->width(), ((MyTextStyleBase*)style())->height());
+    return QRectF(((MyTextStyleBase*)style())->x() + _originalPosition.x(), ((MyTextStyleBase*)style())->y() + _originalPosition.y(), ((MyTextStyleBase*)style())->width(), ((MyTextStyleBase*)style())->height());
 }
 
-void MyTextGraphicsItemBase::adjustOriginalPosition(const QPointF& originalPositionMovedDistance) {
-    ((MyTextStyleBase*)style())->setX(((MyTextStyleBase*)style())->x() - originalPositionMovedDistance.x());
-    ((MyTextStyleBase*)style())->setY(((MyTextStyleBase*)style())->y() - originalPositionMovedDistance.y());
-    _originalPosition += originalPositionMovedDistance;
+void MyTextGraphicsItemBase::moveOriginalPosition(const qreal& dx, const qreal& dy) {
+    _originalPosition += QPointF(dx, dy);
+    My2DShapeGraphicsItemBase::updateExtents();
 }
 
 void MyTextGraphicsItemBase::setZValue(qreal z) {

--- a/src/negui_text_graphics_item.cpp
+++ b/src/negui_text_graphics_item.cpp
@@ -43,10 +43,10 @@ void MyTextGraphicsItemBase::setSelectedWithFillColor(const bool& selected) {
 void MyTextGraphicsItemBase::updateExtents(const QRectF& extents) {
     if (isSetStyle()) {
         // x
-        ((MyTextStyleBase*)style())->setX(extents.x() - _originalPosition.x());
+        ((MyTextStyleBase*)style())->setX(extents.x() - (_originalPosition.x() + _movedOriginalPosition.x()));
         
         // y
-        ((MyTextStyleBase*)style())->setY(extents.y() - _originalPosition.y());
+        ((MyTextStyleBase*)style())->setY(extents.y() - (_originalPosition.y() + _movedOriginalPosition.y()));
         
         // width
         ((MyTextStyleBase*)style())->setWidth(extents.width());
@@ -59,12 +59,13 @@ void MyTextGraphicsItemBase::updateExtents(const QRectF& extents) {
 }
 
 QRectF MyTextGraphicsItemBase::getExtents() {
-    return QRectF(((MyTextStyleBase*)style())->x() + _originalPosition.x(), ((MyTextStyleBase*)style())->y() + _originalPosition.y(), ((MyTextStyleBase*)style())->width(), ((MyTextStyleBase*)style())->height());
+    return QRectF(((MyTextStyleBase*)style())->x() + _originalPosition.x() + _movedOriginalPosition.x(),
+                  ((MyTextStyleBase*)style())->y() + _originalPosition.y() + _movedOriginalPosition.y(),
+                  ((MyTextStyleBase*)style())->width(), ((MyTextStyleBase*)style())->height());
 }
 
 void MyTextGraphicsItemBase::moveOriginalPosition(const qreal& dx, const qreal& dy) {
-    _originalPosition += QPointF(dx, dy);
-    My2DShapeGraphicsItemBase::updateExtents();
+    _movedOriginalPosition += QPointF(dx, dy);
 }
 
 void MyTextGraphicsItemBase::setZValue(qreal z) {

--- a/src/negui_text_graphics_item.h
+++ b/src/negui_text_graphics_item.h
@@ -20,6 +20,8 @@ public:
     
     void setZValue(qreal z) override;
 
+    void updateOriginalPosition(const QPointF originalPosition) override;
+
     void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:

--- a/src/negui_text_graphics_item.h
+++ b/src/negui_text_graphics_item.h
@@ -19,8 +19,8 @@ public:
     QRectF getExtents() override;
     
     void setZValue(qreal z) override;
-    
-    void adjustOriginalPosition(const QPointF& originalPositionMovedDistance) override;
+
+    void moveOriginalPosition(const qreal& dx, const qreal& dy) override;
     
 public slots:
 


### PR DESCRIPTION
 - position function of Node is renamed to getPosition

- setPosition and resetPosition functions of nodes are now deprecated (the position is not stored at all, it always is taken from getExtents funciton)

-  network element mover no longer needs to know which network element is moved by the user

 - updateExtents() function that takes no argument is added to shape graphics item base so that it updates the extents by calling getExtents

- setMovedDistance and movedDistance functions are now deprecated

- adjustOriginalPosition is renamed to moveOriginalPosition and the arguments dx, and dy are given into it

- moveBy and moveExternally functions are all integrated to the move function

- the mechanism an item moved by the user is updated through moving the network element graphics item, passing that move to the shape graphics items and finally zeroing the cache when the graphics item gets updated

- update(QList<MyShapeStyleBase*> shapeStyles, const qint32& zValue) is overridden for MyNodeSceneGraphicsItemBase class to update the original position each time it is called


- askForUpdateConnectedEdgesPoints signal is added and replaced askForResetPosition function

- updateOriginalPosition is called every time getExtents function of the classic nodes is called

-  updateOriginalPosition function is added to the shape graphics items. This function update the style of the shape graphics item relatively to the new original position of the general graphics item associated with a network element


This PR also fixes #135 issue


