### PR TITLE
- update function, which updates the shape style based on the shape s…

### DIFF
--- a/src/negui_1d_shape_style_base.cpp
+++ b/src/negui_1d_shape_style_base.cpp
@@ -43,6 +43,24 @@ const QPen My1DShapeStyleBase::selectedPen() const {
     return pen;
 }
 
+void My1DShapeStyleBase::updatePen(const QPen& pen) {
+    MyParameterBase* parameter = NULL;
+    // border-width
+    parameter = findParameter("border-width");
+    if (parameter)
+        ((MyBorderWidthParameter*)parameter)->setDefaultValue(pen.width());
+
+    // border-color
+    parameter = findParameter("border-color");
+    if (parameter)
+        ((MyBorderColorParameter*)parameter)->setDefaultValue(pen.color().name());
+}
+
+void My1DShapeStyleBase::update(MyShapeStyleBase* shapeStyle) {
+    if (dynamic_cast<My1DShapeStyleBase*>(shapeStyle))
+        updatePen(((My1DShapeStyleBase*)shapeStyle)->pen());
+}
+
 void My1DShapeStyleBase::read(const QJsonObject &json) {
     MyShapeStyleBase::read(json);
     MyParameterBase* parameter = NULL;

--- a/src/negui_1d_shape_style_base.h
+++ b/src/negui_1d_shape_style_base.h
@@ -18,6 +18,10 @@ public:
     // get the pen with selected border color
     const QPen selectedPen() const;
 
+    void updatePen(const QPen& pen);
+
+    void update(MyShapeStyleBase* shapeStyle) override;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 

--- a/src/negui_2d_shape_style_base.cpp
+++ b/src/negui_2d_shape_style_base.cpp
@@ -29,6 +29,20 @@ const QBrush My2DShapeStyleBase::selectedBrush() const {
     return brush;
 }
 
+void My2DShapeStyleBase::updateBrush(const QBrush& brush) {
+    MyParameterBase* parameter = findParameter("fill-color");
+    if (parameter)
+        ((MyFillColorParameter*)parameter)->setDefaultValue(brush.color().name());
+}
+
+void My2DShapeStyleBase::update(MyShapeStyleBase* shapeStyle) {
+    My1DShapeStyleBase::update(shapeStyle);
+    if (dynamic_cast<My2DShapeStyleBase*>(shapeStyle)) {
+        updateBrush(((My2DShapeStyleBase*)shapeStyle)->brush());
+        updateShapeExtents(shapeStyle->getShapeExtents());
+    }
+}
+
 void My2DShapeStyleBase::read(const QJsonObject &json) {
     My1DShapeStyleBase::read(json);
     MyParameterBase* parameter = NULL;

--- a/src/negui_2d_shape_style_base.h
+++ b/src/negui_2d_shape_style_base.h
@@ -16,6 +16,12 @@ public:
     // get the brush with selected fill color
     const QBrush selectedBrush() const;
 
+    void updateBrush(const QBrush& brush);
+
+    virtual void updateShapeExtents(const QRectF& extents) = 0;
+
+    void update(MyShapeStyleBase* shapeStyle) override;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 

--- a/src/negui_centroid_style.h
+++ b/src/negui_centroid_style.h
@@ -20,15 +20,13 @@ public:
     // get the value of radius
     const qreal radius() const;
 
+    void updateShapeExtents(const QRectF& extents) override;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 
     // write the node style info to the json object
     void write(QJsonObject &json) override;
-
-public slots:
-
-    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodeCentroidStyle : public MyCentroidStyleBase {

--- a/src/negui_ellipse_style.h
+++ b/src/negui_ellipse_style.h
@@ -38,15 +38,13 @@ public:
     // get the value of vertical radius
     const qreal radiusY() const;
 
+    void updateShapeExtents(const QRectF& extents) override;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 
     // write the node style info to the json object
     void write(QJsonObject &json) override;
-
-public slots:
-
-    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodeEllipseStyle : public MyEllipseStyleBase {

--- a/src/negui_line_style.cpp
+++ b/src/negui_line_style.cpp
@@ -27,10 +27,6 @@ const QRectF MyLineStyleBase::getShapeExtents() {
     return QRectF(0.0, 0.0, 0.0, 0.0);
 }
 
-void MyLineStyleBase::updateShapeExtents(const QRectF& extents) {
-
-}
-
 void MyLineStyleBase::setRelativeP1(const QPointF& relativeP1) const {
     QPoint point;
     MyParameterBase* parameter = findParameter("ControlPoint1");

--- a/src/negui_line_style.h
+++ b/src/negui_line_style.h
@@ -39,10 +39,6 @@ public:
 
     // write the node style info to the json object
     void write(QJsonObject &json) override;
-
-public slots:
-
-    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyClassicLineStyle : public MyLineStyleBase {

--- a/src/negui_node_style.cpp
+++ b/src/negui_node_style.cpp
@@ -137,7 +137,7 @@ void MySimpleClassicNodeStyle::updateSimpleTextStyleExtentsWithOtherShapeStyleEx
                 otherShapeStyle = shapeStyle;
         }
         if (simpleTextStyle && otherShapeStyle)
-            simpleTextStyle->updateShapeExtents(otherShapeStyle->getShapeExtents());
+            simpleTextStyle->update(otherShapeStyle);
     }
 }
 
@@ -148,7 +148,7 @@ QWidget* MySimpleClassicNodeStyle::shapeStylesButtons() {
 }
 
 void MySimpleClassicNodeStyle::replaceShapeStyle(MyShapeStyleBase* shapeStyle) {
-    shapeStyle->updateShapeExtents(shapeStyles().first()->getShapeExtents());
+    shapeStyle->update(shapeStyles().first());
     _shapeStyles.removeFirst();
     _shapeStyles.push_front(shapeStyle);
 }

--- a/src/negui_polygon_style.h
+++ b/src/negui_polygon_style.h
@@ -29,15 +29,13 @@ public:
     // reset all the values
     void reset() override;
 
+    void updateShapeExtents(const QRectF& extents) override;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 
     // write the node style info to the json object
     void write(QJsonObject &json) override;
-
-public slots:
-
-    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodePolygonStyle : public MyPolygonStyleBase {

--- a/src/negui_rectangle_style.h
+++ b/src/negui_rectangle_style.h
@@ -50,15 +50,13 @@ public:
     // get the y value of border radius
     const qreal borderRadiusY() const;
 
+    void updateShapeExtents(const QRectF& extents) override;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 
     // write the node style info to the json object
     void write(QJsonObject &json) override;
-
-public slots:
-
-    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MyNodeRectangleStyle : public MyRectangleStyleBase {

--- a/src/negui_shape_style_base.h
+++ b/src/negui_shape_style_base.h
@@ -50,6 +50,8 @@ public:
     
     // set the default values of each parameter
     virtual void updateFeatures();
+
+    virtual void update(MyShapeStyleBase* shapeStyle) = 0;
     
     // reset all the values
     virtual void reset();
@@ -63,10 +65,6 @@ public:
 signals:
 
     void isUpdated();
-
-public slots:
-
-    virtual void updateShapeExtents(const QRectF& extents) = 0;
 
 protected:
     QList<MyParameterBase*> _parameters;

--- a/src/negui_single_network_element_feature_menu.cpp
+++ b/src/negui_single_network_element_feature_menu.cpp
@@ -72,7 +72,7 @@ void MySingleNetworkElementFeatureMenu::removeShapeStyle(MyShapeStyleBase* shape
 }
 
 void MySingleNetworkElementFeatureMenu::changeShapeStyle(MyShapeStyleBase* shapeStyle) {
-    shapeStyle->updateShapeExtents(_shapeStyles.first()->getShapeExtents());
+    shapeStyle->update(_shapeStyles.first());
     _shapeStyles.removeFirst();
     addSingleShapeStyle(shapeStyle);
     emit isUpdated(shapeStyles());

--- a/src/negui_text_style.h
+++ b/src/negui_text_style.h
@@ -58,15 +58,13 @@ public:
 
     const qreal calculateTopPaddingRatioToFontHeight(const qreal& pointSize) const ;
 
+    void updateShapeExtents(const QRectF& extents) override;
+
     // read the node style info from the json object
     void read(const QJsonObject &json) override;
 
     // write the node style info to the json object
     void write(QJsonObject &json) override;
-
-public slots:
-
-    void updateShapeExtents(const QRectF& extents) override;
 };
 
 class MySimpleTextStyle : public MyTextStyleBase {


### PR DESCRIPTION
…tyle passed as an input to the function is added to the shape style class

- update function is overridden in both My1DShapeStyleBase and My2DShapeStyleBase classes

- changeShapeStyle function in the single MySingleNetworkElementFeatureMenu calls 'update' function instead of 'updateShapeExtents' function

- replaceShapeStyle function in the single MySimpleClassicNodeStyle calls 'update' function instead of 'updateShapeExtents' function

- updateBrush function is added to the My1DShapeStyleBase class, which updates the brush features based on the input brush

- updatePen function is added to the My1DShapeStyleBase class, which updates the pen features based on the input pen

- updateShapeExtents is no longer a slot and is a public method for the derivative of the 2d shape style base classes. It is also deprecated for MyLineStyleBase


This PR fixes #136 issue