### PR TITLE
Fix the issue with righit clikcing graphics items

### DIFF
--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -7,7 +7,6 @@
 // MyNetworkElementGraphicsItemBase
 
 MyNetworkElementGraphicsItemBase::MyNetworkElementGraphicsItemBase(QGraphicsItem *parent) : QGraphicsItemGroup(parent) {
-    _isChosen = false;
     _originalPosition = QPointF(0.0, 0.0);
     connect(this, SIGNAL(mouseLeftButtonIsPressed()), this, SIGNAL(askForSelectNetworkElement()));
     connect(this, SIGNAL(mouseLeftButtonIsDoubleClicked()), this, SIGNAL(askForEnableFeatureMenuDisplay()));
@@ -120,7 +119,7 @@ QList<QGraphicsItem*> MyNetworkElementGraphicsItemBase::createFocusedGraphicsIte
                 focusedGraphicsItems.push_back((focusedGraphicsItem));
         }
     }
-    
+
     return focusedGraphicsItems;
 }
 
@@ -204,7 +203,7 @@ void MyNetworkElementGraphicsItemBase::setCursor(const QCursor &cursor) {
         item->setCursor(cursor);
     QGraphicsItemGroup::setCursor(cursor);
 }
- 
+
 void MyNetworkElementGraphicsItemBase::clear() {
     for (QGraphicsItem* item : childItems()) {
         removeFromGroup(item);
@@ -221,20 +220,21 @@ void MyNetworkElementGraphicsItemBase::setZValue(qreal z) {
 void MyNetworkElementGraphicsItemBase::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     QGraphicsItem::mousePressEvent(event);
     if (event->button() == Qt::LeftButton) {
-        _isChosen = true;
         emit mouseLeftButtonIsPressed();
         event->accept();
     }
+    else if (event->button() == Qt::RightButton)
+        setFlag(QGraphicsItem::ItemIsMovable, true);
 }
 
 void MyNetworkElementGraphicsItemBase::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
     if (event->button() == Qt::LeftButton) {
-        _isChosen = false;
         event->accept();
         emit askForCreateChangeStageCommand();
     }
     else if (event->button() == Qt::RightButton) {
         displayContextMenu(event->screenPos());
+        setFlag(QGraphicsItem::ItemIsMovable, false);
         event->accept();
     }
     QGraphicsItem::mouseReleaseEvent(event);

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -102,7 +102,6 @@ protected:
     QPointF _originalPosition;
     QList<MyShapeStyleBase*> _shapeStyles;
     QList<QGraphicsItem*> _focusedGraphicsItems;
-    bool _isChosen;
 };
 
 #endif

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -24,11 +24,7 @@ QMenu* MyNodeGraphicsItemBase::createContextMenuObject() {
 
 MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position, QGraphicsItem *parent) : MyNodeGraphicsItemBase(parent) {
     _originalPosition = position;
-    
-    // make it send position changes
-    setFlag(QGraphicsItem::ItemSendsScenePositionChanges, true);
-    
-    // make it focusable
+
     setFlag(QGraphicsItem::ItemIsFocusable, true);
 
     connect(this, SIGNAL(positionChangedByMouseMoveEvent(const QPointF&)), this, SLOT(updateFocusedGraphicsItems()));


### PR DESCRIPTION
- _isChosen attribute of MyNetworkElementGraphicsItemBase class is deprecated

- the issue with GraphicsItemFlag is fixed to make it possbile to right-click on a graphics item

This fixes #140 issue