### PR TITLE
It is now possible to right-click on the edges to get the context menu

### DIFF
--- a/src/negui_arrow_head_graphics_item.cpp
+++ b/src/negui_arrow_head_graphics_item.cpp
@@ -29,6 +29,13 @@ QMenu* MyArrowHeadGraphicsItemBase::createContextMenu() {
     return contextMenu;
 }
 
+void MyArrowHeadGraphicsItemBase::displayContextMenu(const QPoint& position) {
+    if (getSceneMode() == NORMAL_MODE) {
+        QMenu* contextMenu = createContextMenu();
+        contextMenu->exec(position);
+    }
+}
+
 // MyArrowHeadSceneGraphicsItem
 
 MyArrowHeadSceneGraphicsItem::MyArrowHeadSceneGraphicsItem(QGraphicsItem *parent) : MyArrowHeadGraphicsItemBase(parent) {

--- a/src/negui_arrow_head_graphics_item.cpp
+++ b/src/negui_arrow_head_graphics_item.cpp
@@ -30,10 +30,7 @@ QMenu* MyArrowHeadGraphicsItemBase::createContextMenu() {
 }
 
 void MyArrowHeadGraphicsItemBase::displayContextMenu(const QPoint& position) {
-    if (getSceneMode() == NORMAL_MODE) {
-        QMenu* contextMenu = createContextMenu();
-        contextMenu->exec(position);
-    }
+    // no context menu is needed to be displayed for arrow heads
 }
 
 // MyArrowHeadSceneGraphicsItem

--- a/src/negui_arrow_head_graphics_item.h
+++ b/src/negui_arrow_head_graphics_item.h
@@ -17,6 +17,10 @@ public:
     const bool canAddPolygonShape() override;
 
     QMenu* createContextMenu() override;
+
+public slots:
+
+    void displayContextMenu(const QPoint& position) override;
 };
 
 class MyArrowHeadSceneGraphicsItem : public MyArrowHeadGraphicsItemBase {

--- a/src/negui_call_api_function.cpp
+++ b/src/negui_call_api_function.cpp
@@ -227,10 +227,14 @@ const QJsonValue callAPIFunction(QObject* mainWidget, const QString& functionNam
             return ((MyMainWidget*)mainWidget)->listOfNodes();
         else if (functionName == "listOfEdges")
             return ((MyMainWidget*)mainWidget)->listOfEdges();
+        else if (functionName == "listOfArrowHeads")
+            return ((MyMainWidget*)mainWidget)->listOfArrowHeads();
         else if (functionName == "numberOfNodes")
             return ((MyMainWidget*)mainWidget)->numberOfNodes();
         else if (functionName == "numberOfEdges")
             return ((MyMainWidget*)mainWidget)->numberOfEdges();
+        else if (functionName == "numberOfArrowHeads")
+            return ((MyMainWidget*)mainWidget)->numberOfArrowHeads();
     }
 
     return QJsonValue();

--- a/src/negui_edge_graphics_item.cpp
+++ b/src/negui_edge_graphics_item.cpp
@@ -59,6 +59,13 @@ const qreal MyEdgeGraphicsItemBase::getEndSlope() const {
     return endSlope;
 }
 
+void MyEdgeGraphicsItemBase::displayContextMenu(const QPoint& position) {
+    if (getSceneMode() == NORMAL_MODE) {
+        QMenu* contextMenu = createContextMenu();
+        contextMenu->exec(position);
+    }
+}
+
 // MyEdgeSceneGraphicsItemBase
 
 MyEdgeSceneGraphicsItemBase::MyEdgeSceneGraphicsItemBase(QGraphicsItem *parent) : MyEdgeGraphicsItemBase(parent) {

--- a/src/negui_edge_graphics_item.h
+++ b/src/negui_edge_graphics_item.h
@@ -27,6 +27,10 @@ public:
     void adjustStartPointToControlBezierLine(const QLineF& controlBezierLine);
 
     void adjustEndPointToControlBezierLine(const QLineF& controlBezierLine);
+
+public slots:
+
+    void displayContextMenu(const QPoint& position) override;
     
 signals:
     

--- a/src/negui_interactor.cpp
+++ b/src/negui_interactor.cpp
@@ -356,6 +356,14 @@ const qreal MyInteractor::numberOfEdges() {
     return ((MyNetworkManager*)_networkManager)->numberOfEdges();
 }
 
+QJsonArray MyInteractor::listOfArrowHeads() {
+    return ((MyNetworkManager*)_networkManager)->listOfArrowHeads();
+}
+
+const qreal MyInteractor::numberOfArrowHeads() {
+    return ((MyNetworkManager*)_networkManager)->numberOfArrowHeads();
+}
+
 void MyInteractor::adjustConnectedEdgesOfNodes() {
     ((MyNetworkManager*)_networkManager)->askForAdjustConnectedEdgesOfNodes();
 }

--- a/src/negui_interactor.h
+++ b/src/negui_interactor.h
@@ -84,6 +84,8 @@ public slots:
     void deleteEdge(const QString& edgeName);
     QJsonArray listOfEdges();
     const qreal numberOfEdges();
+    QJsonArray listOfArrowHeads();
+    const qreal numberOfArrowHeads();
     void cutSelectedNetworkElements();
     void copySelectedNetworkElements();
     void pasteCopiedNetworkElements();

--- a/src/negui_line_style.cpp
+++ b/src/negui_line_style.cpp
@@ -11,10 +11,10 @@ MyLineStyleBase::MyLineStyleBase(const QString& name) : My1DShapeStyleBase(name)
     addParameter(new MyBorderColorParameter());
     
     // control point 1
-    addParameter(new MyControlPointParameter("ControlPoint1", "First Control Point"));
+    addHiddenParameter(new MyControlPointParameter("ControlPoint1", "First Control Point"));
     
     // control point 2
-    addParameter(new MyControlPointParameter("ControlPoint2", "Second Control Point"));
+    addHiddenParameter(new MyControlPointParameter("ControlPoint2", "Second Control Point"));
 
     reset();
 }

--- a/src/negui_main_widget.cpp
+++ b/src/negui_main_widget.cpp
@@ -471,6 +471,14 @@ const qreal MyMainWidget::numberOfEdges() {
     return ((MyInteractor*)interactor())->numberOfEdges();
 }
 
+QJsonArray MyMainWidget::listOfArrowHeads() {
+    return ((MyInteractor*)interactor())->listOfArrowHeads();
+}
+
+const qreal MyMainWidget::numberOfArrowHeads() {
+    return ((MyInteractor*)interactor())->numberOfArrowHeads();
+}
+
 void MyMainWidget::adjustConnectedEdgesOfNodes() {
     ((MyInteractor*)interactor())->adjustConnectedEdgesOfNodes();
 }

--- a/src/negui_main_widget.h
+++ b/src/negui_main_widget.h
@@ -60,6 +60,8 @@ public slots:
     void deleteEdge(const QString& edgeName);
     QJsonArray listOfEdges();
     const qreal numberOfEdges();
+    QJsonArray listOfArrowHeads();
+    const qreal numberOfArrowHeads();
     void cutSelectedNetworkElements();
     void copySelectedNetworkElements();
     void pasteCopiedNetworkElements();

--- a/src/negui_network_element_graphics_item_base.cpp
+++ b/src/negui_network_element_graphics_item_base.cpp
@@ -247,14 +247,3 @@ void MyNetworkElementGraphicsItemBase::mouseDoubleClickEvent(QGraphicsSceneMouse
     }
     QGraphicsItem::mouseDoubleClickEvent(event);
 }
-
-void MyNetworkElementGraphicsItemBase::displayContextMenu(const QPoint& position) {
-    if (getSceneMode() == NORMAL_MODE) {
-        if (!askForWhetherAnyOtherElementsAreSelected() || !askForWhetherNetworkElementIsSelected()) {
-            QMenu* contextMenu = createContextMenu();
-            contextMenu->exec(position);
-        }
-        else
-            askForDisplaySceneContextMenu(position);
-    }
-}

--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -87,7 +87,7 @@ signals:
 
 public slots:
 
-    void displayContextMenu(const QPoint& position);
+    virtual void displayContextMenu(const QPoint& position) = 0;
 
     void updateFocusedGraphicsItems();
     

--- a/src/negui_network_element_selector.cpp
+++ b/src/negui_network_element_selector.cpp
@@ -28,7 +28,7 @@ void MyNetworkElementSelector::selectNetworkElements(QList<MyNetworkElementBase*
 }
 
 void MyNetworkElementSelector::setNetworkElementSelected(const QString& networkElementName, const bool& selected) {
-    setNetworkElementSelected(getNetworkElement(askForNodes() + askForEdges(), networkElementName), selected);
+    setNetworkElementSelected(getNetworkElement(askForNodes() + askForEdges() + askForArrowHeads(), networkElementName), selected);
 }
 
 void MyNetworkElementSelector::setNetworkElementSelected(MyNetworkElementBase* networkElement, const bool& selected) {

--- a/src/negui_network_element_selector.h
+++ b/src/negui_network_element_selector.h
@@ -74,6 +74,8 @@ signals:
 
     QList<MyNetworkElementBase*> askForEdges();
 
+    QList<MyNetworkElementBase*> askForArrowHeads();
+
     const bool askForWhetherShiftModifierIsPressed();
 
     void askForAddGraphicsItem(QGraphicsItem*);

--- a/src/negui_network_manager.cpp
+++ b/src/negui_network_manager.cpp
@@ -34,9 +34,9 @@ void MyNetworkManager::enableNormalMode() {
     setCopiedEdgeStyle(NULL);
     ((MyNetworkElementSelector*)_networkElementSelector)->enableNormalMode();
     deleteNewEdgeBuilder();
-    for (MyNetworkElementBase *node : qAsConst(nodes()))
+    for (MyNetworkElementBase *node : nodes())
         node->enableNormalMode();
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
+    for (MyNetworkElementBase *edge : edges())
         edge->enableNormalMode();
 }
 
@@ -44,9 +44,9 @@ void MyNetworkManager::enableAddNodeMode(MyPluginItemBase* style) {
     MySceneModeElementBase::enableAddNodeMode();
     setNodeStyle(dynamic_cast<MyNetworkElementStyleBase*>(style));
     ((MyNetworkElementSelector*)_networkElementSelector)->enableAddNodeMode();
-    for (MyNetworkElementBase *node : qAsConst(nodes()))
+    for (MyNetworkElementBase *node : nodes())
         node->enableAddNodeMode();
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
+    for (MyNetworkElementBase *edge : edges())
         edge->enableAddNodeMode();
 }
 
@@ -54,18 +54,18 @@ void MyNetworkManager::enableAddEdgeMode(MyPluginItemBase* style) {
     MySceneModeElementBase::enableAddEdgeMode();
     setEdgeStyle(dynamic_cast<MyNetworkElementStyleBase*>(style));
     ((MyNetworkElementSelector*)_networkElementSelector)->enableAddEdgeMode();
-    for (MyNetworkElementBase *node : qAsConst(nodes()))
+    for (MyNetworkElementBase *node : nodes())
         node->enableAddEdgeMode();
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
+    for (MyNetworkElementBase *edge : edges())
         edge->enableAddEdgeMode();
 }
 
 void MyNetworkManager::enableSelectMode() {
     MySceneModeElementBase::enableSelectMode();
     ((MyNetworkElementSelector*)_networkElementSelector)->enableSelectMode();
-    for (MyNetworkElementBase *node : qAsConst(nodes()))
+    for (MyNetworkElementBase *node : nodes())
         node->enableSelectNodeMode();
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
+    for (MyNetworkElementBase *edge : edges())
         edge->enableSelectEdgeMode();
 }
 
@@ -73,9 +73,9 @@ void MyNetworkManager::enableSelectNodeMode() {
     enableNormalMode();
     MySceneModeElementBase::enableSelectNodeMode();
     ((MyNetworkElementSelector*)_networkElementSelector)->enableSelectNodeMode();
-    for (MyNetworkElementBase *node : qAsConst(nodes()))
+    for (MyNetworkElementBase *node : nodes())
         node->enableSelectNodeMode();
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
+    for (MyNetworkElementBase *edge : edges())
         edge->enableSelectNodeMode();
 }
 
@@ -83,13 +83,13 @@ void MyNetworkManager::enableSelectEdgeMode() {
     enableNormalMode();
     MySceneModeElementBase::enableSelectEdgeMode();
     ((MyNetworkElementSelector*)_networkElementSelector)->enableSelectEdgeMode();
-    for (MyNetworkElementBase *node : qAsConst(nodes()))
+    for (MyNetworkElementBase *node : nodes())
         node->enableSelectEdgeMode();
-    for (MyNetworkElementBase *edge : qAsConst(edges()))
+    for (MyNetworkElementBase *edge : edges())
         edge->enableSelectEdgeMode();
 }
 
-QList<MyNetworkElementBase*>& MyNetworkManager::nodes() {
+QList<MyNetworkElementBase*> MyNetworkManager::nodes() {
     return _nodes;
 }
 
@@ -105,7 +105,7 @@ const qreal MyNetworkManager::numberOfNodes() {
     return nodes().size();
 }
 
-QList<MyNetworkElementBase*>& MyNetworkManager::edges() {
+QList<MyNetworkElementBase*> MyNetworkManager::edges() {
     return _edges;
 }
 
@@ -119,6 +119,28 @@ QJsonArray MyNetworkManager::listOfEdges() {
 
 const qreal MyNetworkManager::numberOfEdges() {
     return edges().size();
+}
+
+QList<MyNetworkElementBase*> MyNetworkManager::arrowHeads() {
+    QList<MyNetworkElementBase*> arrowHeads;
+    for (MyNetworkElementBase* edge : edges()) {
+        if (((MyEdgeBase*)edge)->isSetArrowHead())
+            arrowHeads.push_back(((MyEdgeBase*)edge)->arrowHead());
+    }
+
+    return arrowHeads;
+}
+
+QJsonArray MyNetworkManager::listOfArrowHeads() {
+    QJsonArray listOfArrowHeads;
+    for (MyNetworkElementBase* arrowHead : arrowHeads())
+        listOfArrowHeads.append(arrowHead->name());
+
+    return listOfArrowHeads;
+}
+
+const qreal MyNetworkManager::numberOfArrowHeads() {
+    return arrowHeads().size();
 }
 
 void MyNetworkManager::clearNodesInfo() {
@@ -270,6 +292,7 @@ void MyNetworkManager::setNetworkElementSelector() {
     connect(_networkElementSelector, SIGNAL(askForWhetherShiftModifierIsPressed()), this, SIGNAL(askForWhetherShiftModifierIsPressed()));
     connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::askForNodes, this, [this] () { return nodes(); });
     connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::askForEdges, this, [this] () { return edges(); });
+    connect((MyNetworkElementSelector*)_networkElementSelector, &MyNetworkElementSelector::askForArrowHeads, this, [this] () { return arrowHeads(); });
     connect(_networkElementSelector, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForAddGraphicsItem(QGraphicsItem*)));
     connect(_networkElementSelector, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)), this, SIGNAL(askForRemoveGraphicsItem(QGraphicsItem*)));
 }
@@ -436,7 +459,7 @@ void MyNetworkManager::deleteNode(const QString& nodeName) {
 }
 
 void MyNetworkManager::deleteNode(MyNetworkElementBase* node) {
-    for (MyNetworkElementBase *edge : qAsConst(((MyNodeBase*)node)->edges())) {
+    for (MyNetworkElementBase *edge : ((MyNodeBase*)node)->edges()) {
         ((MyNodeBase*)node)->removeEdge(edge);
         removeEdge(edge);
     }
@@ -455,7 +478,7 @@ void MyNetworkManager::removeNode(MyNetworkElementBase* n) {
 
 void MyNetworkManager::updateNodeParents() {
     MyNetworkElementBase* parentNode = NULL;
-    for (MyNetworkElementBase *node : qAsConst(nodes())) {
+    for (MyNetworkElementBase *node : nodes()) {
         parentNode = findElement(nodes(), ((MyNodeBase*)node)->parentNodeId());
         if (parentNode)
             ((MyNodeBase*)node)->setParentNode((MyNodeBase*)parentNode);
@@ -569,7 +592,7 @@ void MyNetworkManager::moveSelectedNetworkElements(const QPointF& movedDistance)
 
 void MyNetworkManager::deleteSelectedNetworkElements() {
     for (MyNetworkElementBase* selectedNode : getSelectedNodes()) {
-        for (MyNetworkElementBase *edge : qAsConst(((MyNodeBase*)selectedNode)->edges())) {
+        for (MyNetworkElementBase *edge : ((MyNodeBase*)selectedNode)->edges()) {
             ((MyNodeBase*)selectedNode)->removeEdge(edge);
             removeEdge(edge);
         }
@@ -593,11 +616,11 @@ void MyNetworkManager::alignSelectedNetworkElements(const QString& alignType) {
 }
 
 bool MyNetworkManager::isElementNameAlreadyUsed(const QString& elementName) {
-    for (MyNetworkElementBase* node : qAsConst(nodes())) {
+    for (MyNetworkElementBase* node : nodes()) {
         if (node->name() == elementName)
             return true;
     }
-    for (MyNetworkElementBase* edge : qAsConst(edges())) {
+    for (MyNetworkElementBase* edge : edges()) {
         if (edge->name() == elementName)
             return true;
     }
@@ -613,7 +636,7 @@ void MyNetworkManager::deleteNewEdgeBuilder() {
 }
 
 bool MyNetworkManager::edgeExists(MyNetworkElementBase* n1, MyNetworkElementBase* n2) {
-    for (MyNetworkElementBase *edge : qAsConst(edges())) {
+    for (MyNetworkElementBase *edge : edges()) {
         if ((((MyEdgeBase*)edge)->sourceNode() == n1 && ((MyEdgeBase*)edge)->targetNode() == n2) || (((MyEdgeBase*)edge)->sourceNode() == n2 && ((MyEdgeBase*)edge)->targetNode() == n1)) {
             return true;
         }
@@ -630,7 +653,7 @@ QJsonObject MyNetworkManager::getNetworkElementsAndColorInfo() {
 
     // nodes
     QJsonArray nodesArray;
-    for (MyNetworkElementBase *node : qAsConst(nodes())) {
+    for (MyNetworkElementBase *node : nodes()) {
         QJsonObject nodeObject;
         node->write(nodeObject);
         nodesArray.append(nodeObject);
@@ -639,7 +662,7 @@ QJsonObject MyNetworkManager::getNetworkElementsAndColorInfo() {
 
     // edges
     QJsonArray edgesArray;
-    for (MyNetworkElementBase *edge : qAsConst(edges())) {
+    for (MyNetworkElementBase *edge : edges()) {
         QJsonObject edgeObject;
         edge->write(edgeObject);
         edgesArray.append(edgeObject);

--- a/src/negui_network_manager.h
+++ b/src/negui_network_manager.h
@@ -23,17 +23,23 @@ public:
 
     void enableSelectEdgeMode() override;
 
-    QList<MyNetworkElementBase*>& nodes();
+    QList<MyNetworkElementBase*> nodes();
 
     QJsonArray listOfNodes();
 
     const qreal numberOfNodes();
 
-    QList<MyNetworkElementBase*>& edges();
+    QList<MyNetworkElementBase*> edges();
 
     QJsonArray listOfEdges();
 
     const qreal numberOfEdges();
+
+    QList<MyNetworkElementBase*> arrowHeads();
+
+    QJsonArray listOfArrowHeads();
+
+    const qreal numberOfArrowHeads();
 
     void clearNodesInfo();
 

--- a/src/negui_node_graphics_item.cpp
+++ b/src/negui_node_graphics_item.cpp
@@ -20,6 +20,17 @@ QMenu* MyNodeGraphicsItemBase::createContextMenuObject() {
     return new MyNodeGraphicsItemContextMenuBase();
 }
 
+void MyNodeGraphicsItemBase::displayContextMenu(const QPoint& position) {
+    if (getSceneMode() == NORMAL_MODE) {
+        if (!askForWhetherAnyOtherElementsAreSelected() || !askForWhetherNetworkElementIsSelected()) {
+            QMenu* contextMenu = createContextMenu();
+            contextMenu->exec(position);
+        }
+        else
+            askForDisplaySceneContextMenu(position);
+    }
+}
+
 // MyNodeSceneGraphicsItemBase
 
 MyNodeSceneGraphicsItemBase::MyNodeSceneGraphicsItemBase(const QPointF &position, QGraphicsItem *parent) : MyNodeGraphicsItemBase(parent) {

--- a/src/negui_node_graphics_item.h
+++ b/src/negui_node_graphics_item.h
@@ -15,6 +15,10 @@ public:
 
     virtual QMenu* createContextMenuObject();
 
+public slots:
+
+    void displayContextMenu(const QPoint& position) override;
+
 signals:
 
     const QLineF askForGetBezierAdjustLine();


### PR DESCRIPTION
- network manager gives the users the access to arrowHeads, numberOfArrowHeads, and listOfArrowHeads
    
    - this access to the arrowHeads names, list, size is passed to the api functions

- display context menu is no longer displayed for arrow head graphics item

- displayContextMenu function is set to be a virtual function and is moved to each network element graphics item

This PR fixes #133 issue
