### PR TITLE
Display Context Menu signals are updated (second attempt)

### DIFF
--- a/src/negui_network_element_graphics_item_base.h
+++ b/src/negui_network_element_graphics_item_base.h
@@ -64,8 +64,8 @@ public:
 signals:
     
     void mouseLeftButtonIsPressed();
-    void mouseRightButtonIsReleased(const QPointF&);
     void mouseLeftButtonIsDoubleClicked();
+    void mouseRightButtonIsReleased(const QPointF&);
     void askForSelectNetworkElement();
     const bool askForWhetherNetworkElementIsSelected();
     void askForAddGraphicsItem(QGraphicsItem*);


### PR DESCRIPTION
- createContextMenu and displayContextMenu functions are moved to the derived classes MyNodeGraphicsItem and MyEdgeGraphicsItem

- mouseRightButtonIsReleased signal replaced call to displayContextMenu function when mouseReleaseEvent with RightButton is called

- MyArrowHeadGraphicsItemContextMenu class is now deprecated

- mouseRightButtonIsReleased signal of _arrowHeadGraphicsItem graphics item of edge is connected to the displayContextMenu of that edge